### PR TITLE
Add key translation functionality

### DIFF
--- a/evil-collection-ag.el
+++ b/evil-collection-ag.el
@@ -31,6 +31,8 @@
 (require 'evil)
 (require 'evil-collection-evil-search)
 
+(defconst evil-collection-ag-maps '(ag-mode-map))
+
 (defun evil-collection-ag-setup ()
   "Set up `evil' bindings for `ag'."
   (evil-define-key '(normal visual) ag-mode-map

--- a/evil-collection-alchemist.el
+++ b/evil-collection-alchemist.el
@@ -30,6 +30,17 @@
 (require 'evil)
 (require 'alchemist nil t)
 
+(defconst evil-collection-alchemist-maps '(alchemist-compile-mode-map
+                                           alchemist-eval-mode-map
+                                           alchemist-execute-mode-map
+                                           alchemist-message-mode-map
+                                           alchemist-help-minor-mode-map
+                                           alchemist-macroexpand-mode-map
+                                           alchemist-mix-mode-map
+                                           alchemist-test-report-mode-map
+                                           alchemist-mode-map))
+
+
 (defun evil-collection-alchemist-setup ()
   "Set up `evil' bindings for `alchemist'."
   (evil-set-initial-state 'alchemist-compile-mode 'normal)

--- a/evil-collection-anaconda-mode.el
+++ b/evil-collection-anaconda-mode.el
@@ -29,6 +29,9 @@
 (require 'anaconda-mode nil t)
 (require 'evil)
 
+(defconst evil-collection-anaconda-mode-maps '(anaconda-mode-view-mode-map
+                                               anaconda-mode-map))
+
 (defun evil-collection-anaconda-mode-setup ()
   "Set up `evil' bindings for `anaconda-mode'."
   ;; Bindings don't seem to be set the first time.

--- a/evil-collection-arc-mode.el
+++ b/evil-collection-arc-mode.el
@@ -30,6 +30,8 @@
 (require 'arc-mode)
 (require 'evil)
 
+(defconst evil-collection-arc-mode-maps '(archive-mode-map))
+
 (defun evil-collection-arc-mode-setup ()
   "Set up `evil' bindings for `arc-mode'."
   (evil-set-initial-state 'arc-mode 'normal)

--- a/evil-collection-bookmark.el
+++ b/evil-collection-bookmark.el
@@ -29,6 +29,8 @@
 ;;; Code:
 (require 'bookmark)
 
+(defconst evil-collection-bookmark-maps '(bookmark-bmenu-mode-map))
+
 (defun evil-collection-bookmark-setup ()
   "Set up `evil' bindings for `bookmark'."
   (evil-set-initial-state 'bookmark-bmenu-mode 'normal)

--- a/evil-collection-buff-menu.el
+++ b/evil-collection-buff-menu.el
@@ -34,6 +34,8 @@
 (require 'evil)
 (require 'tabulated-list)
 
+(defconst evil-collection-buff-menu-maps '(Buffer-menu-mode-map))
+
 ;; This is for `evil-collection-Buffer-menu-unmark-all-buffers.'
 (defsubst evil-collection-buff-menu-tabulated-list-header-overlay-p (&optional pos)
   "Return non-nil if there is a fake header.

--- a/evil-collection-calc.el
+++ b/evil-collection-calc.el
@@ -29,6 +29,8 @@
 (require 'evil-collection-util)
 (require 'calc)
 
+(defconst evil-collection-calc-maps '(calc-mode-map))
+
 (defun evil-collection-calc-ext-setup ()
   "Set up `evil' bindings for `calc'.
 Since calc bindings are set on-demand when calc-ext is load, we

--- a/evil-collection-calendar.el
+++ b/evil-collection-calendar.el
@@ -30,6 +30,8 @@
 (require 'calendar)
 (require 'evil)
 
+(defconst evil-collection-calendar-maps '(calendar-mode-map))
+
 (defun evil-collection-calendar-setup ()
   "Set up `evil' bindings for `calendar'."
   (evil-set-initial-state 'calendar-mode 'normal)

--- a/evil-collection-cider.el
+++ b/evil-collection-cider.el
@@ -34,6 +34,12 @@
 
 (declare-function cider-debug-mode-send-reply "cider-debug")
 
+(defconst evil-collection-cider-maps '(cider-mode-map
+                                       cider-repl-mode-map
+                                       cider-test-report-mode-map
+                                       cider-macroexpansion-mode-map
+                                       cider-connections-buffer-mode-map))
+
 (defun evil-collection-cider-last-sexp (command &rest args)
   "In normal-state or motion-state, last sexp ends at point."
   (if (and (not evil-move-beyond-eol)

--- a/evil-collection-comint.el
+++ b/evil-collection-comint.el
@@ -30,6 +30,8 @@
 (require 'comint)
 (require 'evil)
 
+(defconst evil-collection-comint-maps '(comint-mode-map))
+
 (defun evil-collection-comint-setup ()
   "Set up `evil' bindings for `comint'."
   (when evil-want-C-d-scroll

--- a/evil-collection-company.el
+++ b/evil-collection-company.el
@@ -50,6 +50,8 @@ be set through custom or before evil-collection loads."
 (defvar company-active-map)
 (defvar company-search-map)
 
+(defconst evil-collection-company-maps '(company-active-map company-search-map))
+
 (defun evil-collection-company-setup ()
   "Set up `evil' bindings for `company'."
   (define-key company-active-map (kbd "C-n") 'company-select-next-or-abort)

--- a/evil-collection-compile.el
+++ b/evil-collection-compile.el
@@ -31,6 +31,8 @@
 (require 'compile)
 (require 'evil-collection-evil-search)
 
+(defconst evil-collection-compile-maps '(compilation-mode-map))
+
 (defun evil-collection-compile-setup ()
   "Set up `evil' bindings for `compile'."
   (evil-set-initial-state 'compilation-mode 'normal)

--- a/evil-collection-cus-theme.el
+++ b/evil-collection-cus-theme.el
@@ -30,6 +30,9 @@
 (require 'cus-theme)
 (require 'evil)
 
+(defconst evil-collection-cus-theme-maps '(custom-theme-choose-mode-map
+                                           custom-new-theme-mode-map))
+
 (defun evil-collection-cus-theme-setup ()
   "Set up `evil' bindings for `cus-theme'."
   (evil-set-initial-state 'custom-new-theme-mode 'normal)

--- a/evil-collection-custom.el
+++ b/evil-collection-custom.el
@@ -30,6 +30,8 @@
 (require 'cus-edit)
 (require 'evil)
 
+(defconst evil-collection-custom-maps '(custom-mode-map))
+
 (defun evil-collection-custom-setup ()
   "Set up `evil' bindings for `Custom-mode'."
   (evil-set-initial-state 'Custom-mode 'normal)

--- a/evil-collection-daemons.el
+++ b/evil-collection-daemons.el
@@ -30,6 +30,9 @@
 (require 'daemons nil t)
 (require 'evil)
 
+(defconst evil-collection-daemons-maps '(daemons-mode-map
+                                         daemons-output-mode-map))
+
 (defun evil-collection-daemons-setup ()
   "Set up `evil' bindings for `daemons'."
   (evil-define-key '(normal visual) daemons-mode-map

--- a/evil-collection-debbugs.el
+++ b/evil-collection-debbugs.el
@@ -30,6 +30,8 @@
 (require 'debbugs nil t)
 (require 'evil)
 
+(defconst evil-collection-debbugs-maps '(debbugs-gnu-mode-map))
+
 (defun evil-collection-debbugs-setup ()
   "Set up `evil' bindings for `debbugs-gnu-mode'."
   (evil-set-initial-state 'debbugs-gnu-mode 'normal)

--- a/evil-collection-debug.el
+++ b/evil-collection-debug.el
@@ -31,6 +31,8 @@
 (require 'evil)
 (require 'debug)
 
+(defconst evil-collection-debug-maps '(debugger-mode-map))
+
 (defun evil-collection-debug-setup ()
   "Set up `evil' bindings for `debug'."
   (evil-set-initial-state 'debugger-mode 'normal)

--- a/evil-collection-diff-mode.el
+++ b/evil-collection-diff-mode.el
@@ -38,6 +38,8 @@
 (require 'evil)
 (require 'diff-mode)
 
+(defconst evil-collection-diff-mode-maps '(diff-mode-map))
+
 (defun evil-collection-diff-read-only-state-switch ()
   "Make read-only in motion state, writable in normal state."
   (if buffer-read-only

--- a/evil-collection-dired.el
+++ b/evil-collection-dired.el
@@ -30,6 +30,8 @@
 (require 'dired)
 (require 'evil)
 
+(defconst evil-collection-dired-maps '(dired-mode-map))
+
 (defun evil-collection-dired-setup ()
   "Set up `evil' bindings for `dired'."
   (evil-define-key 'normal dired-mode-map

--- a/evil-collection-doc-view.el
+++ b/evil-collection-doc-view.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'doc-view)
 
+(defconst evil-collection-doc-view-maps '(doc-view-mode-map))
+
 (defun evil-collection-doc-view-setup ()
   "Set up `evil' bindings for `doc-view'."
   (evil-set-initial-state 'doc-view-mode 'normal)

--- a/evil-collection-edebug.el
+++ b/evil-collection-edebug.el
@@ -30,6 +30,11 @@
 (require 'edebug)
 (require 'evil)
 
+(defconst evil-collection-edebug-maps
+  '(edebug-mode-map
+    edebug-x-instrumented-function-list-mode-map
+    edebug-x-breakpoint-list-mode-map))
+
 (defun evil-collection-edebug-setup ()
   "Set up `evil' bindings for `edebug'."
   (evil-set-initial-state 'edebug-mode 'normal)

--- a/evil-collection-elfeed.el
+++ b/evil-collection-elfeed.el
@@ -33,6 +33,9 @@
 (defvar elfeed-search-mode-map)
 (defvar elfeed-show-mode-map)
 
+(defconst evil-collection-elfeed-maps '(elfeed-search-mode-map
+                                        elfeed-show-mode-map))
+
 (defun evil-collection-elfeed-setup ()
   "Set up `evil' bindings for `elfeed'."
 

--- a/evil-collection-elisp-mode.el
+++ b/evil-collection-elisp-mode.el
@@ -30,6 +30,8 @@
 (require 'elisp-mode)
 (require 'evil)
 
+(defconst evil-collection-elisp-mode-maps nil)
+
 (defun evil-collection-elisp-mode-last-sexp-setup-props (beg end value alt1 alt2)
   "Set up text properties for the output of `elisp--eval-last-sexp'.
 BEG and END are the start and end of the output in current-buffer.

--- a/evil-collection-elisp-refs.el
+++ b/evil-collection-elisp-refs.el
@@ -31,6 +31,8 @@
 (require 'evil)
 (require 'elisp-refs nil t)
 
+(defconst evil-collection-elisp-refs-maps '(elisp-refs-mode-map))
+
 (defun evil-collection-elisp-refs-setup ()
   "Set up `evil' bindings for `elisp-refs'."
   (evil-define-key 'normal elisp-refs-mode-map

--- a/evil-collection-emms.el
+++ b/evil-collection-emms.el
@@ -36,6 +36,9 @@
 (defvar emms-browser-mode-map)
 (defvar emms-playlist-mode-map)
 
+(defconst evil-collection-emms-maps '(emms-browser-mode-map
+                                      emms-playlist-mode-map))
+
 (defun evil-collection-emms-playlist-mode-insert-newline-above ()
   "Insert a newline above point."
   (interactive)

--- a/evil-collection-epa.el
+++ b/evil-collection-epa.el
@@ -31,6 +31,10 @@
 (require 'evil)
 (require 'epa nil t)
 
+(defconst evil-collection-epa-maps '(epa-key-list-mode-map
+                                     epa-key-mode-map
+                                     epa-info-mode-map))
+
 (defun evil-collection-epa-setup ()
   (evil-define-key 'normal epa-key-list-mode-map
     (kbd "<tab>") 'widget-forward

--- a/evil-collection-eshell.el
+++ b/evil-collection-eshell.el
@@ -31,6 +31,8 @@
 (require 'eshell)
 (require 'evil)
 
+(defconst evil-collection-eshell-maps '(eshell-mode-map))
+
 (defun evil-collection-eshell-next-prompt ()
   "`evil' wrapper around `eshell-next-prompt'."
   (when (get-text-property (point) 'read-only)

--- a/evil-collection-eval-sexp-fu.el
+++ b/evil-collection-eval-sexp-fu.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'eval-sexp-fu nil t)
 
+(defconst evil-collection-eval-sexp-fu-maps nil)
+
 (defun evil-collection-eval-sexp-fu-bounds-of-thing-at-point-sexp (command &rest args)
   "In normal-state or motion-state, last sexp ends at point."
   (if (and (eq (nth 0 args) 'sexp)

--- a/evil-collection-eww.el
+++ b/evil-collection-eww.el
@@ -30,6 +30,11 @@
 (require 'eww)
 (require 'evil-collection-util)
 
+(defvar evil-collection-eww-maps '(eww-mode-map
+                                   eww-history-mode-map
+                                   eww-buffers-mode-map
+                                   eww-bookmark-mode-map))
+
 (defun evil-collection-eww-setup ()
   "Set up `evil' bindings for `eww'."
 

--- a/evil-collection-flycheck.el
+++ b/evil-collection-flycheck.el
@@ -32,6 +32,8 @@
 
 (defvar flycheck-error-list-mode-map)
 
+(defconst evil-collection-flycheck-maps '(flycheck-error-list-mode-map))
+
 (defun evil-collection-flycheck-setup ()
   "Set up `evil' bindings for `flycheck'."
   (evil-set-initial-state 'flycheck-error-list-mode 'normal)

--- a/evil-collection-free-keys.el
+++ b/evil-collection-free-keys.el
@@ -31,6 +31,8 @@
 ;;; Code:
 (defvar free-keys-mode-map)
 
+(defconst evil-collection-free-keys-maps '(free-keys-mode-map))
+
 (defun evil-collection-free-keys-set-header-line-format ()
   "Tweak `header-line-format' locally for `free-keys'."
   (setq-local header-line-format

--- a/evil-collection-geiser.el
+++ b/evil-collection-geiser.el
@@ -33,6 +33,11 @@
 (defvar geiser-debug-mode-map)
 (defvar geiser-doc-mode-map)
 
+(defconst evil-collection-geiser-maps '(geiser-debug-mode-map
+                                        geiser-doc-mode-map
+                                        geiser-repl-mode-map
+                                        geiser-mode-map))
+
 (defun evil-collection-geiser-last-sexp (command &rest args)
   "In normal-state or motion-state, last sexp ends at point."
   (if (and (not evil-move-beyond-eol)

--- a/evil-collection-ggtags.el
+++ b/evil-collection-ggtags.el
@@ -36,6 +36,11 @@
 (defvar ggtags-view-tag-history-mode-map)
 (defvar ggtags-navigation-map)
 
+(defconst evil-collection-ggtags-maps '(ggtags-mode-map
+                                        ggtags-view-search-history-mode-map
+                                        ggtags-view-tag-history-mode-map
+                                        ggtags-navigation-map))
+
 (defun evil-collection-ggtags-setup ()
   "Set up `evil' bindings for `ggtags'."
   (evil-set-initial-state 'ggtags-global-mode 'normal)

--- a/evil-collection-go-mode.el
+++ b/evil-collection-go-mode.el
@@ -24,11 +24,15 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `go-mode'.
+;; Bindings for `go-mode'.
+
+;;; Code:
 (require 'evil)
 (require 'go-mode nil t)
 
-;;; Code:
+(defconst evil-collection-go-mode-maps '(go-mode-map
+                                         godoc-mode-map))
+
 (defun evil-collection-go-mode-setup ()
   "Set up `evil' bindings for `go-mode'."
   (evil-define-key 'normal go-mode-map

--- a/evil-collection-helm.el
+++ b/evil-collection-helm.el
@@ -48,6 +48,14 @@
 
 (declare-function helm-window "helm-lib")
 
+(defconst evil-collection-helm-maps '(help-map
+                                      help-find-files-map
+                                      helm-read-file-map
+                                      helm-generic-files-map
+                                      helm-buffer-map
+                                      helm-moccur-map
+                                      helm-grep-map))
+
 ;; From https://github.com/emacs-helm/helm/issues/362.
 ;; Also see https://emacs.stackexchange.com/questions/17058/change-cursor-type-in-helm-header-line#17097.
 ;; TODO: With Evil, the cursor type is not right in the header line and the evil
@@ -112,6 +120,7 @@
                    :background (face-background 'default)))
            header-line-format)
           (when update (force-mode-line-update)))))))
+
 
 (defun evil-collection-helm-setup ()
   "Set up `evil' bindings for `helm'."

--- a/evil-collection-help.el
+++ b/evil-collection-help.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'help-mode)
 
+(defconst evil-collection-help-maps '(help-mode-map))
+
 (defun evil-collection-help-setup ()
   "Set up `evil' bindings for `help'."
   (evil-set-initial-state 'help-mode 'normal)

--- a/evil-collection-ibuffer.el
+++ b/evil-collection-ibuffer.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'ibuffer)
 
+(defconst evil-collection-ibuffer-maps '(ibuffer-mode-map))
+
 (defun evil-collection-ibuffer-setup ()
   "Set up `evil' bindings for `ibuffer'."
   (evil-set-initial-state 'ibuffer-mode 'normal)

--- a/evil-collection-image+.el
+++ b/evil-collection-image+.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'image+ nil t)
 
+(defconst evil-collection-image+-maps '(image-mode-map))
+
 (defun evil-collection-image+-setup ()
   "Set up `evil' bindings for `image+'."
   (evil-define-key 'normal image-mode-map

--- a/evil-collection-image.el
+++ b/evil-collection-image.el
@@ -33,6 +33,8 @@
 ;; TODO: pdf and doc-view conflict with image.
 ;; See https://github.com/emacs-evil/evil-collection/issues/23.
 
+(defconst evil-collection-image-maps '(image-mode-map))
+
 (defun evil-collection-image-setup ()
   "Set up `evil' bindings for `image-mode'."
   (evil-set-initial-state 'image-mode 'normal)

--- a/evil-collection-indium.el
+++ b/evil-collection-indium.el
@@ -24,11 +24,18 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `indium'.
+;; Bindings for `indium'.
 
 ;;; Code:
 (require 'evil-collection-settings)
 (require 'indium nil t)
+
+(defconst evil-collection-indium-maps '(indium-debugger-mode-map
+                                        indium-inspector-mode-map
+                                        indium-debugger-locals-mode-map
+                                        indium-debugger-frames-mode-map
+                                        indium-interaction-mode-map
+                                        indium-repl-mode-map))
 
 (defun evil-collection-indium-setup ()
   "Set up `evil' bindings for `indium'."

--- a/evil-collection-info.el
+++ b/evil-collection-info.el
@@ -32,6 +32,8 @@
 (require 'evil-collection-evil-search)
 (require 'info)
 
+(defconst evil-collection-info-maps '(Info-mode-map))
+
 (defun evil-collection-info-setup ()
   "Set up `evil' bindings for `info-mode'."
   (evil-collection-util-inhibit-insert-state Info-mode-map)

--- a/evil-collection-ivy.el
+++ b/evil-collection-ivy.el
@@ -30,6 +30,10 @@
 (require 'evil)
 (require 'ivy nil t)
 
+(defconst evil-collection-ivy-maps '(ivy-occur-mode-map
+                                     ivy-occur-grep-mode-map
+                                     ivy-minibuffer-map))
+
 (defun evil-collection-ivy-setup ()
   "Set up `evil' bindings for `ivy-mode'."
   (evil-define-key 'normal ivy-occur-mode-map

--- a/evil-collection-kotlin-mode.el
+++ b/evil-collection-kotlin-mode.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'kotlin-mode nil t)
 
+(defconst evil-collection-kotlin-maps '(kotlin-mode-map))
+
 (defun evil-collection-kotlin-mode-setup ()
   "Set up `evil' bindings for `kotlin-mode'."
   (evil-define-key 'normal kotlin-mode-map "gz" 'kotlin-repl))

--- a/evil-collection-log-view.el
+++ b/evil-collection-log-view.el
@@ -24,11 +24,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `log-view'
+;; Bindings for `log-view'.
+
+;;; Code:
 (require 'evil)
 (require 'log-view)
 
-;;; Code:
+(defconst evil-collection-log-view-maps '(log-view-mode-map))
+
 (defun evil-collection-log-view-setup ()
   "Set up `evil' bindings for `log-view'."
   (evil-define-key 'normal log-view-mode-map

--- a/evil-collection-lua-mode.el
+++ b/evil-collection-lua-mode.el
@@ -32,6 +32,8 @@
 
 (defvar lua-indent-level)
 
+(defconst evil-collection-lua-mode-maps '(lua-mode-map))
+
 (defun evil-collection-lua-mode-set-evil-shift-width ()
   "Set `evil-shift-width' according to `lua-indent-level'."
   (setq evil-shift-width lua-indent-level))

--- a/evil-collection-macrostep.el
+++ b/evil-collection-macrostep.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'macrostep nil t)
 
+(defconst evil-collection-macrostep-maps '(macrostep-keymap))
+
 (defun evil-collection-macrostep-setup ()
   "Set up `evil' bindings for `macrostep'."
   ;; Keymaps don't seem to be populated on first try.

--- a/evil-collection-man.el
+++ b/evil-collection-man.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'man)
 
+(defconst evil-collection-man-maps '(Man-mode-map))
+
 (defun evil-collection-man-setup ()
   "Set up `evil' bindings for `man'."
   (evil-set-initial-state 'Man-mode 'normal)

--- a/evil-collection-minibuffer.el
+++ b/evil-collection-minibuffer.el
@@ -29,6 +29,13 @@
 ;;; Code:
 (require 'evil)
 
+(defconst evil-collection-minibuffer-maps '(minibuffer-local-map
+                                            minibuffer-local-ns-map
+                                            minibuffer-local-completion-map
+                                            minibuffer-local-must-match-map
+                                            minibuffer-local-isearch-map
+                                            evil-ex-completion-map))
+
 (defun evil-collection-minibuffer-insert ()
   "Switch to insert state.
 

--- a/evil-collection-neotree.el
+++ b/evil-collection-neotree.el
@@ -31,6 +31,8 @@
 (require 'evil)
 (require 'neotree nil t)
 
+(defconst evil-collection-neotree-maps '(neotree-mode-map))
+
 (defun evil-collection-neotree-setup ()
   "Set up `evil' bindings for `neotree'."
 

--- a/evil-collection-notmuch.el
+++ b/evil-collection-notmuch.el
@@ -36,6 +36,13 @@
 (declare-function notmuch-search-tag "notmuch")
 (declare-function notmuch-tree-tag "notmuch-tree")
 
+(defconst evil-collection-notmuch-maps '(notmuch-common-keymap
+                                         notmuch-hello-mode-map
+                                         notmuch-show-mode-map
+                                         notmuch-tree-mode-map
+                                         notmuch-search-mode-map
+                                         notmuch-search-stash-map))
+
 (defun evil-collection-notmuch-show-toggle-delete ()
   "Toggle deleted tag for message."
   (interactive)

--- a/evil-collection-nov.el
+++ b/evil-collection-nov.el
@@ -31,6 +31,9 @@
 (require 'nov nil t)
 
 (defvar nov-mode-map)
+
+(defconst evil-collection-nov-maps '(nov-mode-map))
+
 (defun evil-collection-nov-setup ()
   "Set up `evil' bindings for `nov'."
   (evil-define-key 'normal nov-mode-map

--- a/evil-collection-occur.el
+++ b/evil-collection-occur.el
@@ -32,6 +32,9 @@
 (when (> emacs-major-version 25)
   (require 'replace))
 
+(defconst evil-collection-occur-maps '(occur-mode-map
+                                       occur-edit-mode-map))
+
 (defun evil-collection-occur-setup ()
   "Set up `evil' bindings for `occur'."
   (evil-set-initial-state 'occur-mode 'normal)

--- a/evil-collection-outline.el
+++ b/evil-collection-outline.el
@@ -40,6 +40,8 @@ mode."
   :group 'evil-collection-outline
   :type 'boolean)
 
+(defconst evil-collection-outline-maps '(outline-mode-map))
+
 (defun evil-collection-outline-setup ()
   "Set up `evil' bindings for `outline'."
   (evil-set-initial-state 'outline-mode 'normal)

--- a/evil-collection-p4.el
+++ b/evil-collection-p4.el
@@ -31,6 +31,8 @@
 
 (defvar p4-basic-mode-map)
 
+(defconst evil-collection-p4-maps '(p4-basic-mode-map))
+
 (defun evil-collection-p4-setup ()
   "Set up `evil' bindings for `p4'."
   (evil-set-initial-state 'p4-basic-mode 'normal)

--- a/evil-collection-package-menu.el
+++ b/evil-collection-package-menu.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'package)
 
+(defconst evil-collection-package-menu-maps '(package-menu-mode-map))
+
 (defun evil-collection-package-menu-setup ()
   "Set up `evil' bindings for `package-menu'."
   (evil-set-initial-state 'package-menu-mode 'normal)

--- a/evil-collection-pass.el
+++ b/evil-collection-pass.el
@@ -32,6 +32,8 @@
 
 (defvar pass-mode-map)
 
+(defconst evil-collection-pass-maps '(pass-mode-map))
+
 (defun evil-collection-pass-setup ()
   "Set up `evil' bindings for `pass-mode'."
   (evil-define-key 'normal pass-mode-map

--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -31,6 +31,10 @@
 (require 'pdf-tools nil t)
 (require 'pdf-view nil t)
 
+(defconst evil-collection-pdf-maps '(pdf-view-mode-map
+                                     pdf-outline-buffer-mode-map
+                                     pdf-occur-buffer-mode-map))
+
 (declare-function pdf-view-last-page "pdf-view")
 (declare-function pdf-view-first-page "pdf-view")
 (declare-function pdf-view-goto-page "pdf-view")

--- a/evil-collection-popup.el
+++ b/evil-collection-popup.el
@@ -24,11 +24,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `popup'.
+;; Bindings for `popup'.
+
+;;; Code:
 (require 'evil)
 (require 'popup nil t)
 
-;;; Code:
+(defconst evil-collection-popup-maps '(popup-menu-keymap))
+
 (defun evil-collection-popup-setup ()
   "Set up `evil' bindings for `popup'."
   (defvar popup-menu-keymap)

--- a/evil-collection-proced.el
+++ b/evil-collection-proced.el
@@ -30,6 +30,8 @@
 (require 'evil-collection-util)
 (require 'proced)
 
+(defconst evil-collection-proced-maps '(proced-mode-map))
+
 (defun evil-collection-proced-setup ()
   "Set up `evil' bindings for `proced'."
   (evil-collection-util-inhibit-insert-state proced-mode-map)

--- a/evil-collection-prodigy.el
+++ b/evil-collection-prodigy.el
@@ -30,6 +30,9 @@
 (require 'evil)
 (require 'prodigy nil t)
 
+(defconst evil-collection-prodigy-maps '(prodigy-mode-map
+                                         prodigy-view-mode-map))
+
 (defun evil-collection-prodigy-setup ()
   "Set up `evil' bindings for `prodigy'."
   (evil-define-key 'normal prodigy-mode-map

--- a/evil-collection-profiler.el
+++ b/evil-collection-profiler.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'profiler)
 
+(defconst evil-collection-profiler-maps '(profiler-report-mode-map))
+
 (defun evil-collection-profiler-setup ()
   "Set up `evil' bindings for `profiler'."
   (evil-set-initial-state 'profiler-report-mode 'normal)

--- a/evil-collection-python.el
+++ b/evil-collection-python.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'python)
 
+(defconst evil-collection-python-maps '(python-mode-map))
+
 (defun evil-collection-python-set-evil-shift-width ()
   "Set `evil-shift-width' according to `python-indent-offset'."
   (setq evil-shift-width python-indent-offset))

--- a/evil-collection-quickrun.el
+++ b/evil-collection-quickrun.el
@@ -24,11 +24,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `quickrun'.
+;; Bindings for `quickrun'.
+
+;;; Code:
 (require 'evil)
 (require 'quickrun nil t)
 
-;;; Code:
+(defconst evil-collection-quickrun-maps '(quickrun--mode-map))
+
 (defun evil-collection-quickrun-setup ()
   "Set up `evil' bindings for `quickrun'.."
   (evil-define-key 'normal quickrun--mode-map

--- a/evil-collection-racer.el
+++ b/evil-collection-racer.el
@@ -24,11 +24,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `racer'.
+;; Bindings for `racer'.
 
 ;;; Code:
 (require 'evil)
 (require 'racer nil t)
+
+(defconst evil-collection-racer-maps '(racer-mode-map
+                                       racer-help-mode-map))
 
 (defun evil-collection-racer-setup ()
   "Set up `evil' bindings for `racer'."

--- a/evil-collection-realgud.el
+++ b/evil-collection-realgud.el
@@ -24,11 +24,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `realgud'.
+;; Bindings for `realgud'.
+
+;;; Code:
 (require 'evil)
 (require 'realgud nil t)
 
-;;; Code:
+(defconst evil-collection-realgud-maps '(realgud:shortkey-mode-map))
+
 (defun evil-collection-realgud-setup ()
   "Set up `evil' bindings for `realgud'."
   ;; This one is to represent `realgud-populate-src-buffer-map-plain'.

--- a/evil-collection-reftex.el
+++ b/evil-collection-reftex.el
@@ -32,6 +32,9 @@
 (require 'reftex-ref nil t)
 (require 'reftex-cite nil t)
 
+(defconst evil-collection-reftex-maps '(reftex-select-shared-map
+                                        reftex-toc-mode-map))
+
 ;; original code can be found in reftex-ref.el
 (setq reftex-select-label-prompt
   "Select: [RET]select [j]next [k]previous [gr]escan [go]context [q]uit [g?]help")

--- a/evil-collection-rjsx-mode.el
+++ b/evil-collection-rjsx-mode.el
@@ -32,6 +32,8 @@
 
 (defvar rjsx-mode-map)
 
+(defconst evil-collection-rjsx-maps '(rjsx-mode-map))
+
 (defun evil-collection-rjsx-mode-setup ()
   "Set up `evil' bindings for `rjsx-mode'."
   (when evil-want-C-d-scroll

--- a/evil-collection-robe.el
+++ b/evil-collection-robe.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'robe nil t)
 
+(defconst evil-collection-robe-maps '(robe-mode-map))
+
 (defun evil-collection-robe-setup ()
   "Set up `evil' bindings for `robe'."
   (evil-define-key 'normal robe-mode-map

--- a/evil-collection-rtags.el
+++ b/evil-collection-rtags.el
@@ -35,6 +35,11 @@
 (defvar rtags-references-tree-mode-map)
 (defvar rtags-location-stack-visualize-mode-map)
 
+(defconst evil-collection-rtags-maps '(rtags-mode-map
+                                       rtags-dependency-tree-mode-map
+                                       rtags-references-tree-mode-map
+                                       rtags-location-stack-visualize-mode-map))
+
 (defun evil-collection-rtags-setup ()
   "Set up `evil' bindings for `rtags'."
   (evil-set-initial-state 'rtags-mode 'normal)

--- a/evil-collection-ruby-mode.el
+++ b/evil-collection-ruby-mode.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'ruby-mode)
 
+(defconst evil-collection-ruby-mode-maps nil)
+
 (defun evil-collection-ruby-mode-set-evil-shift-width ()
   "Set `evil-shift-width' according to `ruby-indent-level'."
   (setq evil-shift-width ruby-indent-level))

--- a/evil-collection-simple.el
+++ b/evil-collection-simple.el
@@ -24,14 +24,16 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `simple'
+;; Bindings for `simple'
 
+;;; Code:
 (require 'evil)
 (require 'simple)
 
 (defvar special-mode-map)
 
-;;; Code:
+(defconst evil-collection-simple-maps '(special-mode-map))
+
 (defun evil-collection-simple-setup ()
   "Set up `evil' bindings for `simple'."
   (evil-define-key '(normal visual) special-mode-map

--- a/evil-collection-slime.el
+++ b/evil-collection-slime.el
@@ -37,6 +37,13 @@
 (defvar slime-popup-buffer-mode-map)
 (defvar slime-xref-mode-map)
 
+(defconst evil-collection-slime-maps '(slime-parent-map
+                                       sldb-mode-map
+                                       slime-inspector-mode-map
+                                       slime-mode-map
+                                       slime-popup-buffer-mode-map
+                                       slime-xref-mode-map ))
+
 (defun evil-collection-slime-last-sexp (command &rest args)
   "In normal-state or motion-state, last sexp ends at point."
   (if (and (not evil-move-beyond-eol)

--- a/evil-collection-term.el
+++ b/evil-collection-term.el
@@ -60,6 +60,9 @@ This is only used if `evil-collection-term-sync-state-and-mode-p' is true."
 
 ;; TODO: Add support for normal-state editing.
 
+(defconst evil-collection-term-maps '(term-raw-map
+                                      term-mode-map))
+
 (defun evil-collection-term-escape-stay ()
   "Go back to normal state but don't move cursor backwards.
 Moving cursor backwards is the default Vim behavior but

--- a/evil-collection-tide.el
+++ b/evil-collection-tide.el
@@ -30,6 +30,10 @@
 (require 'tide nil t)
 (require 'evil)
 
+(defconst evil-collection-tide-maps '(tide-mode-map
+                                      tide-references-mode-map
+                                      tide-project-errors-mode-map))
+
 (defun evil-collection-tide-setup ()
   "Set up `evil' bindings for `tide'."
   (evil-define-key 'normal tide-mode-map

--- a/evil-collection-transmission.el
+++ b/evil-collection-transmission.el
@@ -36,6 +36,11 @@
 (defvar transmission-info-mode-map)
 (defvar transmission-peers-mode-map)
 
+(defconst evil-collection-transmission-maps '(transmission-mode-map
+                                              transmission-files-mode-map
+                                              transmission-info-mode-map
+                                              transmission-peers-mode-map))
+
 (defun evil-collection-transmission-setup ()
   "Set up `evil' bindings for `transmission'."
 

--- a/evil-collection-vc-annotate.el
+++ b/evil-collection-vc-annotate.el
@@ -24,11 +24,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `vc-annotate'
+;; Bindings for `vc-annotate'
+
+;;; Code:
 (require 'evil)
 (require 'vc-annotate)
 
-;;; Code:
+(defconst evil-collection-vc-annotate-maps '(vc-annotate-mode-map))
+
 (defun evil-collection-vc-annotate-setup ()
   "Set up `evil' bindings for `vc-annotate'."
   (evil-set-initial-state 'vc-annotate-mode 'normal)

--- a/evil-collection-view.el
+++ b/evil-collection-view.el
@@ -24,11 +24,13 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Evil bindings for View.
+;; Evil bindings for View.
 
 ;;; Code:
 (require 'evil)
 (require 'view)
+
+(defconst evil-collection-view-maps '(view-mode-map))
 
 (defun evil-collection-view-setup ()
   "Set up `evil' bindings for `view'."

--- a/evil-collection-vlf.el
+++ b/evil-collection-vlf.el
@@ -33,6 +33,8 @@
 (defvar vlf-mode-map)
 (declare-function vlf-change-batch-size "vlf")
 
+(defconst evil-collection-vlf-maps '(vlf-mode-map))
+
 (defun evil-collection-vlf-decrease-batch-size ()
   "Decrease vlf batch size by factor of 2."
   (interactive)

--- a/evil-collection-which-key.el
+++ b/evil-collection-which-key.el
@@ -33,6 +33,8 @@
 
 (defvar which-key-C-h-map)
 
+(defconst evil-collection-which-key-maps '(which-key-C-h-map))
+
 ;; `which-key'is coded so that the prompt properly shows j and k as
 ;; the bindings.
 (defun evil-collection-which-key-setup ()

--- a/evil-collection-woman.el
+++ b/evil-collection-woman.el
@@ -31,6 +31,8 @@
 (require 'evil-collection-man) ; WoMan's keymap inherits from Man.
 (require 'woman)
 
+(defconst evil-collection-woman-maps '(woman-mode-map))
+
 (defun evil-collection-woman-setup ()
   "Set up `evil' bindings for `woman'."
   (evil-set-initial-state 'woman-mode 'normal)

--- a/evil-collection-xref.el
+++ b/evil-collection-xref.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'xref)
 
+(defconst evil-collection-xref-maps '(xref--xref-buffer-mode-map))
+
 (defun evil-collection-xref-setup ()
   "Set up `evil' bindings for `xref'."
   (evil-define-key 'normal xref--xref-buffer-mode-map

--- a/evil-collection-ztree.el
+++ b/evil-collection-ztree.el
@@ -32,6 +32,8 @@
 (defvar ztree-mode-map)
 (defvar ztreediff-mode-map)
 
+(defconst evil-collection-ztree-maps '(ztree-mode-map ztreediff-mode-map))
+
 (defun evil-collection-ztree-setup ()
   "Set up `evil' bindings for `ztree'."
 

--- a/readme.org
+++ b/readme.org
@@ -384,6 +384,122 @@ definition".
     - ~f11~ Step Into
     - ~S-f11~ Step Out
 
+** Key Translation
+~evil-collection-translate-key~ allows binding a key to the definition of
+another key in the same keymap (comparable to how vim's keybindings work). Its
+arguments are the ~states~ and ~keymaps~ to bind/look up the key(s) in followed
+optionally by keyword arguments (currently only ~:destructive~) and
+key/replacement pairs. ~states~ should be nil for non-evil keymaps, and both
+~states~ and ~keymaps~ can be a single symbol or a list of symbols.
+
+This function can be useful for making key swaps/cycles en masse. For example,
+someone who uses an alternate keyboard layout may want to retain the ~hjkl~
+positions for directional movement in dired, the calendar, etc.
+
+Here's an example for Colemak of making swaps in a single keymap:
+#+begin_src emacs-lisp
+(evil-collection-translate-key nil 'evil-motion-state-map
+  ;; colemak hnei is qwerty hjkl
+  "n" "j"
+  "e" "k"
+  "i" "l"
+  ;; add back nei
+  "j" "e"
+  "k" "n"
+  "l" "i")
+#+end_src
+
+Here's an example of using ~evil-collection-setup-hook~ to cycle the keys for
+all modes in ~evil-collection-mode-list~:
+#+begin_src emacs-lisp
+(defun my-hjkl-rotation (_mode mode-keymaps &rest _rest)
+  (evil-collection-translate-key 'normal mode-keymaps
+    "n" "j"
+    "e" "k"
+    "i" "l"
+    "j" "e"
+    "k" "n"
+    "l" "i"))
+
+;; called after evil-collection makes its keybindings
+(add-hook 'evil-collection-setup-hook #'my-hjkl-rotation)
+
+(evil-collection-init)
+#+end_src
+
+A more common use case of ~evil-collection-translate-key~ would be for keeping
+the functionality of some keys that users may bind globally. For example, ~SPC~,
+~[~, and ~]~ are bound in some modes. If you use these keys as global prefix
+keys that you never want to be overriden, you'll want to give them higher
+priority than other evil keybindings (e.g. those made by ~(evil-define-key
+'normal some-map ...)~). To do this, you can create an "intercept" map and bind
+your prefix keys in it instead of in ~evil-normal-state-map~:
+#+begin_src emacs-lisp
+(defvar my-intercept-mode-map (make-sparse-keymap)
+  "High precedence keymap.")
+
+(define-minor-mode my-intercept-mode
+  "Global minor mode for higher precedence evil keybindings."
+  :global t)
+
+(my-intercept-mode)
+
+(dolist (state '(normal visual insert))
+  (evil-make-intercept-map
+   ;; NOTE: This requires an evil version from 2018-03-20 or later
+   (evil-get-auxiliary-keymap my-intercept-mode-map state t t)
+   state))
+
+(evil-define-key 'normal my-intercept-mode-map
+  (kbd "SPC f") 'find-file)
+;; ...
+#+end_src
+
+You can then define replacement keys:
+#+begin_src emacs-lisp
+(defun my-prefix-translations (_mode mode-keymaps &rest _rest)
+  (evil-collection-translate-key 'normal mode-keymaps
+    "C-SPC" "SPC"
+    ;; these need to be unbound first; this needs to be in same statement
+    "[" nil
+    "]" nil
+    "[[" "["
+    "]]" "]"))
+
+(add-hook 'evil-collection-setup-hook #'my-prefix-translation)
+
+(evil-collection-init)
+#+end_src
+
+By default, the first invocation of ~evil-collection-translate-key~ will make a
+backup of the keymap. Each subsequent invocation will look up keys in the backup
+instead of the original. This means that a call to
+~evil-collection-translate-key~ will always have the same behavior even if
+evaluated multiple times. When ~:destructive t~ is specified, keys are looked up
+in the keymap as it is currently. This means that a call to
+~evil-collection-translate-key~ that swapped two keys would continue to
+swap/unswap them with each call. Therefore when ~:destructive t~ is used, all
+cycles/swaps must be done within a single call to
+~evil-collection-translate-key~. To make a comparison to Vim keybindings,
+~:destructive t~ is comparable to Vim's ~map~, and ~:destructive nil~ is
+comparable to vim's ~noremap~ (where the "original" keybindings are those that
+existed in the keymap when ~evil-collection-translate-key~ was first called).
+You'll almost always want to use the default behavior (especially in your init
+file). The limitation of ~:destructive nil~ is that you can't translate a key to
+another key that was defined after the first ~evil-collection-translate-key~, so
+~:destructive t~ may be useful for interactive experimentation.
+
+~evil-collection-swap-key~ is also provided as a wrapper around
+~evil-colletion-translate-key~ that allows swapping keys:
+#+begin_src emacs-lisp
+(evil-collection-swap-key nil 'evil-motion-state-map
+  ";" ":")
+;; is equivalent to
+(evil-collection-translate-key nil 'evil-motion-state-map
+  ";" ":"
+  ":" ";")
+#+end_src
+
 ** Modes left behind
 
 Some modes might still remain unsupported by this package.  Should you be


### PR DESCRIPTION
This commit isn't ready to be merged. Any feedback would be appreciated. Some notes:

- in the readme, I'll add detailed explanation and an example of defining `evil-collection-user-setup-function` with some example swaps
- `cl-lib` is added as an explicit dependency (already used by evil)
- I added a macro wrapper for swapping keys: `evil-collection-swap-key`
- I've removed the general.el-specific functionality; the general.el versions have tests; I haven't tested the evil-collection versions yet but will do so before finalizing the pull request

I think that a `evil-collection-mode-map-(p|a)list` should be added (would a plist or alist be preferred?). It would pair each mode with a list of keymap names for that mode (I can add this). This would require more work to maintain, but I think that it's necessary given that a significant number of these modes have multiple keymaps (e.g. elfeed).

I also think that more may need to be done to make it easy to limit the scope of translations. For example, `hjkl` swaps are only desirable in keymaps that rebind `hjkl` to the mode-specific navigation keys. For this case, it's probably not an issue, since if `hjkl` are all unbound in the keymap, all new definitions will just be nil (those positions will still be bound to the default `evil-next-line`, `evil-previous-line`, etc.). I think the main case where this could be an issue is for keys that can have different meanings (e.g. if `o` happened to be used for something else in modes where there is no sorting and the user only wanted to translate a key to `o` in modes where it is used for sorting). These situations would require users to create their own blacklists/whitelists. I'm not sure about how much of an issue this could be, whether it would make sense to have `evil-collection` provide information about the types of keybindings made in each mode, or whether there is some other solution. I think this can be addressed with a later pull request if necessary.