### PR TITLE
Add binding to trigger notmuch-show-part-map

### DIFF
--- a/evil-collection-notmuch.el
+++ b/evil-collection-notmuch.el
@@ -39,6 +39,7 @@
 (defconst evil-collection-notmuch-maps '(notmuch-common-keymap
                                          notmuch-hello-mode-map
                                          notmuch-show-mode-map
+                                         notmuch-show-part-map
                                          notmuch-tree-mode-map
                                          notmuch-search-mode-map
                                          notmuch-search-stash-map))
@@ -115,7 +116,8 @@
     "-" 'notmuch-show-remove-tag
     "+" 'notmuch-show-add-tag
     (kbd "TAB") 'notmuch-show-toggle-message
-    (kbd "RET") 'notmuch-show-toggle-message)
+    (kbd "RET") 'notmuch-show-toggle-message
+    "." 'notmuch-show-part-map)
 
   (evil-define-key 'normal notmuch-tree-mode-map
     "g?" (notmuch-tree-close-message-pane-and 'notmuch-help)


### PR DESCRIPTION
Missing binding to trigger `show-part-map`, which prevents some useful functionality from being exposed to evil-mode (e.g. [integrating diff viewing][1]).

  [1]: https://notmuchmail.org/emacstips/#index25h2