### PR TITLE
Expose the tag-all helper to the notmuch-search-mode map

### DIFF
--- a/evil-collection-notmuch.el
+++ b/evil-collection-notmuch.el
@@ -152,6 +152,7 @@
     "K" 'notmuch-tag-jump
     "o" 'notmuch-search-toggle-order
     "Z" 'notmuch-tree-from-search-current-query
+    "*" 'notmuch-search-tag-all
     "a" 'notmuch-search-archive-thread
     "c" 'compose-mail
     "d" 'evil-collection-notmuch-search-toggle-delete


### PR DESCRIPTION
Its exposed in the default mapping but not exposed in the evil mode remapping.