### PR TITLE
Support git-timemachine

### DIFF
--- a/evil-collection-git-timemachine.el
+++ b/evil-collection-git-timemachine.el
@@ -1,8 +1,24 @@
 ;;; evil-collection-git-timemachine.el --- Bindings for `git-timemachine' -*- lexical-binding: t -*-
+
 ;; Author: William Carroll <wpcarro@gmail.com>
+;; URL: https://github.com/emacs-evil/evil-collection
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; Evil keybindings for `git-timemachine' that conform to the principles outlines in evil-collection
+;; Evil keybindings for `git-timemachine' that conform to the principles
+;; outlines in evil-collection
 
 ;;; Code:
 (require 'evil)

--- a/evil-collection-git-timemachine.el
+++ b/evil-collection-git-timemachine.el
@@ -1,0 +1,22 @@
+;;; evil-collection-git-timemachine.el --- Bindings for `git-timemachine' -*- lexical-binding: t -*-
+;; Author: William Carroll <wpcarro@gmail.com>
+
+;;; Commentary:
+;; Evil keybindings for `git-timemachine' that conform to the principles outlines in evil-collection
+
+;;; Code:
+(require 'evil)
+(require 'git-timemachine)
+
+(defun ecgt--setup-bindings ()
+  "Setup `git-timemachine' since `evil-set-initial-state' is unavailable to
+minor modes."
+  (evil-motion-state nil)
+  (evil-local-set-key 'motion "n" #'git-timemachine-show-next-revision))
+
+(defun evil-collection-git-timemachine-setup ()
+  "Setup `evil' keybindings for `git-timemachine'."
+  (add-hook 'git-timemachine-mode-hook #'ecgt--setup-bindings))
+
+(provide 'evil-collection-git-timemachine)
+;;; evil-collection-git-timemachine.el ends here

--- a/evil-collection-git-timemachine.el
+++ b/evil-collection-git-timemachine.el
@@ -22,17 +22,22 @@
 
 ;;; Code:
 (require 'evil)
-(require 'git-timemachine)
+(require 'git-timemachine nil t)
 
-(defun ecgt--setup-bindings ()
-  "Setup `git-timemachine' since `evil-set-initial-state' is unavailable to
-minor modes."
-  (evil-motion-state nil)
-  (evil-local-set-key 'motion "n" #'git-timemachine-show-next-revision))
+(defvar git-timemachine-mode-map)
+(defconst evil-collection-git-timemachine-map '(git-timemachine-mode-map))
 
 (defun evil-collection-git-timemachine-setup ()
   "Setup `evil' keybindings for `git-timemachine'."
-  (add-hook 'git-timemachine-mode-hook #'ecgt--setup-bindings))
+  (evil-define-minor-mode-key 'normal 'git-timemachine-mode
+    "\C-k" #'git-timemachine-show-previous-revision
+    "\C-j" #'git-timemachine-show-next-revision
+    "q"    #'git-timemachine-quit
+    "gtg"  #'git-timemachine-show-nth-revision
+    "gtt"  #'git-timemachine-show-revision-fuzzy
+    "gty"  #'git-timemachine-kill-abbreviated-revision
+    "gtY"  #'git-timemachine-kill-revision
+    "gtb"  #'git-timemachine-blame))
 
 (provide 'evil-collection-git-timemachine)
 ;;; evil-collection-git-timemachine.el ends here


### PR DESCRIPTION
Supports evil bindings for git-timemachine. On my machine, git-timemachine
starts with evil in normal mode, which is problematic when trying to access the
keybindings "n" and "p", which navigate to the next and previous revisions.
Additionally, normal mode eclispses "q", which exits the mode.

I tried using `(evil-set-initial-state 'git-timemachine-mode 'motion)`, but that
didn't work. I assume this is because `git-timemachine` is a minor-mode. To work
around this, I used `add-hook` to ensure motion mode was the initial state.

Once motion mode is the initial state, "p" and "q" become available.
Unfortunately, "n" is still unavailable. To get around this, I used a
buffer-local binding in the local motion state to map "n" appropriately. One
known shortcoming of this approach is that there is no cleanup done after
exiting the mode. Therefore, "n" is still mapped in the local motion map after
`git-timemachine` is quit. This doesn't feel great.

Any suggestions are eagerly welcomed. Forgive any crude techniques that I used
to get this functioning. I just wanted to broach the discussion with some of the
other maintainers to get some insights and hopefully augment my implementation
as needed.

Additionally, if "n" and "p" are not the preferred Evil idioms, please let me
know, and I'll adopt whatever is recommended. It is convenient that "n" and "p"
are set my `git-timemachine` by default, since they also are the Vim way of
searching next and previous items...