### PR TITLE
Add support for dd in wgrep buffers

### DIFF
--- a/evil-collection-wgrep.el
+++ b/evil-collection-wgrep.el
@@ -34,12 +34,44 @@
 
 (defconst evil-collection-wgrep-maps '(wgrep-mode-map))
 
+(evil-define-operator evil-collection-wgrep-delete (beg end type register yank-handler)
+  "Delete text from BEG to END with TYPE.
+Save in REGISTER or in the kill-ring with YANK-HANDLER."
+  (interactive "<R><x><y>")
+  (unless register
+    (let ((text (filter-buffer-substring beg end)))
+      (unless (string-match-p "\n" text)
+        ;; set the small delete register
+        (evil-set-register ?- text))))
+  (let ((evil-was-yanked-without-register nil))
+    (evil-yank beg end type register yank-handler))
+  (cond
+   ((eq type 'block)
+    (evil-apply-on-block #'delete-region beg end nil))
+   ((eq type 'line)
+    (if (and (= end (point-max))
+             (or (= beg end)
+                 (/= (char-before end) ?\n))
+             (/= beg (point-min))
+             (=  (char-before beg) ?\n))
+        (delete-region (1- beg) end)
+      (dotimes (_ (count-lines beg end))
+        (wgrep-mark-deletion)
+        (evil-next-line))))
+   (t
+    (delete-region beg end)))
+  ;; place cursor on beginning of line
+  (when (and (called-interactively-p 'any)
+             (eq type 'line))
+    (evil-first-non-blank)))
+
 (defun evil-collection-wgrep-setup ()
   "Set up `evil' bindings for `wgrep'."
   (evil-define-key nil wgrep-mode-map
     [remap evil-write] 'wgrep-finish-edit)
 
   (evil-define-key 'normal wgrep-mode-map
+    "d" 'evil-collection-wgrep-delete
     "ZQ" 'wgrep-abort-changes
     "ZZ" 'wgrep-finish-edit
     (kbd "<escape>") 'wgrep-exit))


### PR DESCRIPTION
This seems to be the only way to define `dd` without losing the functionality of
the rest of the `d`-prefixed keys. This should allow regular `d` operations as
well as `dd` to remove the target line.

This is just a copy of the `evil-delete` operator from [evil source](https://github.com/emacs-evil/evil/blob/c3317f8d1bd60405a2c3aad372da126651a74fbe/evil-commands.el#L1348-L1374). And
builds upon what I mentioned earlier in:

https://github.com/emacs-evil/evil-collection/pull/111