### PR TITLE
Use evil-ex-search when requested in info mode

### DIFF
--- a/evil-collection-emms.el
+++ b/evil-collection-emms.el
@@ -115,6 +115,11 @@ The return value is the yanked text."
     "gy" 'emms-browse-by-year
     "gc" 'emms-browse-by-composer
     "gp" 'emms-browse-by-performer
+    "zm" 'emms-browser-collapse-all
+    "zr" 'emms-browser-expand-all
+    "zo" 'emms-browser-expand-one-level
+    ;; TODO find a real replacement for zc
+    "zc" 'emms-browser-collapse-all
 
     ;; TODO find a way to integrate this with evil-collection-evil-search
     "/" 'emms-isearch-buffer ; This shows hidden items during search.

--- a/evil-collection-emms.el
+++ b/evil-collection-emms.el
@@ -116,6 +116,7 @@ The return value is the yanked text."
     "gc" 'emms-browse-by-composer
     "gp" 'emms-browse-by-performer
 
+    ;; TODO find a way to integrate this with evil-collection-evil-search
     "/" 'emms-isearch-buffer ; This shows hidden items during search.
     "n" 'isearch-repeat-forward
     "N" 'isearch-repeat-backward

--- a/evil-collection-evil-search.el
+++ b/evil-collection-evil-search.el
@@ -31,6 +31,8 @@
 ;;; Code:
 (require 'evil-search)
 
+(defvar evil-collection-evil-search-enabled (eq evil-search-module 'evil-search))
+
 (defvar evil-collection-evil-search-forward
   '(menu-item "" nil :filter (lambda (&optional _)
                                (if (eq evil-search-module 'evil-search)

--- a/evil-collection-evil-search.el
+++ b/evil-collection-evil-search.el
@@ -31,7 +31,8 @@
 ;;; Code:
 (require 'evil-search)
 
-(defvar evil-collection-evil-search-enabled (eq evil-search-module 'evil-search))
+(defun evil-collection-evil-search-enabled ()
+  (eq evil-search-module 'evil-search))
 
 (defvar evil-collection-evil-search-forward
   '(menu-item "" nil :filter (lambda (&optional _)

--- a/evil-collection-info.el
+++ b/evil-collection-info.el
@@ -71,10 +71,10 @@
 
     ;; TODO: Should search with "n"/"N" cover the full manual like "C-s"/"C-r" does?
     ;; TODO: Directions?
-    "n" (if evil-collection-evil-search-enabled
+    "n" (if (evil-collection-evil-search-enabled)
             evil-collection-evil-search-next
           'isearch-repeat-forward)
-    "N" (if evil-collection-evil-search-enabled
+    "N" (if (evil-collection-evil-search-enabled)
             evil-collection-evil-search-previous
           'isearch-repeat-backward)
 

--- a/evil-collection-info.el
+++ b/evil-collection-info.el
@@ -71,8 +71,12 @@
 
     ;; TODO: Should search with "n"/"N" cover the full manual like "C-s"/"C-r" does?
     ;; TODO: Directions?
-    "n" 'isearch-repeat-forward
-    "N" 'isearch-repeat-backward
+    "n" (if evil-collection-evil-search-enabled
+            evil-collection-evil-search-next
+          'isearch-repeat-forward)
+    "N" (if evil-collection-evil-search-enabled
+            evil-collection-evil-search-previous
+          'isearch-repeat-backward)
 
     ;; goto
     "gd" 'Info-goto-node ; TODO: "gd" does not match the rationale of "go to definition". Change?


### PR DESCRIPTION
I also added "folding" to the emms binds, although, it's not a perfect match (there's no "collapse one tree" command, and "expand-one-level" run repeatedly breaks the tree). For some reason, isearch in emms dosen't seem to search all folds for me, but I don't mind too much, so I'm not touching that for now.

Let me know if anything seems wrong. 

Closes #122