### PR TITLE
Force isearch in pdf mode

### DIFF
--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -136,6 +136,11 @@
     ;; search
     (kbd "M-s o") 'pdf-occur ; TODO: More Evil bindings?
 
+    "/" #'isearch-forward
+    "?" #'isearch-backward
+    "n" #'isearch-repeat-forward
+    "N" #'isearch-repeat-backward
+
     "zd" 'pdf-view-dark-minor-mode
     "zm" 'pdf-view-midnight-minor-mode
     "zp" 'pdf-view-printer-minor-mode

--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -51,14 +51,16 @@
   (interactive "P")
   (if page
       (pdf-view-goto-page page)
-    (pdf-view-last-page)))
+    (pdf-view-last-page)
+    (image-eob)))
 
 (defun evil-collection-pdf-view-goto-first-page (&optional page)
   "`evil' wrapper around `pdf-view-first-page'."
   (interactive "P")
   (if page
       (pdf-view-goto-page page)
-    (pdf-view-first-page)))
+    (pdf-view-first-page)
+    (image-bob)))
 
 (defun evil-collection-pdf-setup ()
   "Set up `evil' bindings for `pdf-view'."


### PR DESCRIPTION
For PDF files, the default evil search dosen't seem to work at all (for me), so I think it's better to just force isearch on here so people have something.

I also made gg/G scroll to the absolute start/end of the document by scrolling to the top/bottom of the image after navigating to the correct page. This fixes scrolling down a couple lines and then pressing `gg`
