### PR TITLE
Abort company search with single <escape>

### DIFF
--- a/evil-collection-company.el
+++ b/evil-collection-company.el
@@ -71,6 +71,7 @@ be set through custom or before evil-collection loads."
   (define-key company-search-map (kbd "C-k") 'company-select-previous-or-abort)
   (define-key company-search-map (kbd "M-j") 'company-select-next)
   (define-key company-search-map (kbd "M-k") 'company-select-previous)
+  (define-key company-search-map (kbd "<escape>") 'company-search-abort)
 
   ;; Sets up YCMD like behavior.
   (when evil-collection-company-use-tng (company-tng-configure-default)))


### PR DESCRIPTION
This originates from my init file. There are two keymaps in company where one can abort, but by default with "\e\e\e" instead of a single hit. Curiously enough in Evil a single hit works out of the box for regular completion candidates, but in the search it doesn't.  This PR fixes it for the latter.