### PR TITLE
add a count to pdf-tool's next-line-or-next-page

### DIFF
--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -46,6 +46,22 @@
 (defvar pdf-outline-buffer-mode-map)
 (defvar pdf-occur-buffer-mode-map)
 
+(defun evil-collection-pdf-view-next-line-or-next-page (&optional count)
+  "'evil' wrapper include a count argument to `pdf-view-next-line-or-next-page'"
+  (interactive "P")
+  (if count
+      (dotimes (_ count nil)
+	(pdf-view-next-line-or-next-page 1))
+    (pdf-view-next-line-or-next-page 1)))
+
+(defun evil-collection-pdf-view-previous-line-or-previous-page (&optional count)
+  "'evil' wrapper include a count argument to `pdf-view-previous-line-or-previous-page'"
+  (interactive "P")
+  (if count
+      (dotimes (_ count nil)
+	(pdf-view-previous-line-or-previous-page 1))
+    (pdf-view-previous-line-or-previous-page 1)))
+
 (defun evil-collection-pdf-view-goto-page (&optional page)
   "`evil' wrapper around `pdf-view-last-page'."
   (interactive "P")
@@ -69,8 +85,8 @@
   (evil-define-key 'normal pdf-view-mode-map
     ;; motion
     (kbd "<return>") 'image-next-line
-    "j" 'pdf-view-next-line-or-next-page
-    "k" 'pdf-view-previous-line-or-previous-page
+    "j" 'evil-collection-pdf-view-next-line-or-next-page
+    "k" 'evil-collection-pdf-view-previous-line-or-previous-page
     (kbd "SPC") 'pdf-view-scroll-up-or-next-page
     (kbd "S-SPC") 'pdf-view-scroll-down-or-previous-page
     (kbd "<delete>") 'pdf-view-scroll-down-or-previous-page
@@ -84,8 +100,8 @@
     "gk" 'pdf-view-previous-page-command
     (kbd "<next>") 'forward-page
     (kbd "<prior>") 'backward-page
-    (kbd "<down>") 'pdf-view-next-line-or-next-page
-    (kbd "<up>") 'pdf-view-previous-line-or-previous-page
+    (kbd "<down>") 'evil-collection-pdf-view-next-line-or-next-page
+    (kbd "<up>") 'evil-collection-pdf-view-previous-line-or-previous-page
     "gg" 'evil-collection-pdf-view-goto-first-page
     "G" 'evil-collection-pdf-view-goto-page
 

--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -46,6 +46,12 @@
 (defvar pdf-outline-buffer-mode-map)
 (defvar pdf-occur-buffer-mode-map)
 
+;; TODO: The following 2 functions are workarounds for
+;; 'pdf-view-next-line-or-next-page' and
+;; 'pdf-view-previous-line-or-previous-page' not playing well with
+;; EVIL. The root cause should be found and fixed instead.
+;; See https://github.com/emacs-evil/evil-collection/pull/137 for
+;; details.
 (defun evil-collection-pdf-view-next-line-or-next-page (&optional count)
   "'evil' wrapper include a count argument to `pdf-view-next-line-or-next-page'"
   (interactive "P")


### PR DESCRIPTION
For some reason the count arguments for `pdf-view-next-line-or-next-page` and `pdf-view-previous-line-or-previous-page` only work for `<down>` and `<up>`, but not `j` and `k`. As in, `2 <down>` scrolls down by 2 pages as expected, but `2 j` scrolls down by 2 pages.

After a bit of experimentation, the best solution so far is wrapping the functions in a `dotimes`. After that fix, and both worked for all of the mentioned keys.