### PR TITLE
Fix #135: Whitelist, blacklist and binding record

### DIFF
--- a/evil-collection-ace-jump-mode.el
+++ b/evil-collection-ace-jump-mode.el
@@ -139,9 +139,10 @@ the mark and entering `recursive-edit'."
     (when evil-collection-ace-jump-mode-jump-active
       (add-hook 'post-command-hook #'evil-collection-ace-jump-mode-jump-exit-recursive-edit)))
 
-  (define-key evil-motion-state-map [remap ace-jump-char-mode] #'evil-ace-jump-char-mode)
-  (define-key evil-motion-state-map [remap ace-jump-line-mode] #'evil-ace-jump-line-mode)
-  (define-key evil-motion-state-map [remap ace-jump-word-mode] #'evil-ace-jump-word-mode))
+  (evil-collection-define-key nil 'evil-motion-state-map
+    [remap ace-jump-char-mode] #'evil-ace-jump-char-mode
+    [remap ace-jump-line-mode] #'evil-ace-jump-line-mode
+    [remap ace-jump-word-mode] #'evil-ace-jump-word-mode))
 
 (provide 'evil-collection-ace-jump-mode)
 ;;; evil-collection-ace-jump-mode.el ends here

--- a/evil-collection-ag.el
+++ b/evil-collection-ag.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-ag-setup ()
   "Set up `evil' bindings for `ag'."
-  (evil-define-key '(normal visual) ag-mode-map
+  (evil-collection-define-key '(normal visual) 'ag 'ag-mode-map
     "k" 'evil-previous-line
     "h" 'evil-backward-char
 

--- a/evil-collection-ag.el
+++ b/evil-collection-ag.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-ag-setup ()
   "Set up `evil' bindings for `ag'."
-  (evil-collection-define-key '(normal visual) 'ag 'ag-mode-map
+  (evil-collection-define-key '(normal visual) 'ag-mode-map
     "k" 'evil-previous-line
     "h" 'evil-backward-char
 

--- a/evil-collection-alchemist.el
+++ b/evil-collection-alchemist.el
@@ -54,19 +54,19 @@
   (evil-set-initial-state 'alchemist-test-mode 'normal)
   (evil-set-initial-state 'alchemist-test-report-mode 'normal)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-compile-mode-map
+  (evil-collection-define-key 'normal 'alchemist-compile-mode-map
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-eval-mode-map
+  (evil-collection-define-key 'normal 'alchemist-eval-mode-map
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-execute-mode-map
+  (evil-collection-define-key 'normal 'alchemist-execute-mode-map
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-message-mode-map
+  (evil-collection-define-key 'normal 'alchemist-message-mode-map
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-help-minor-mode-map
+  (evil-collection-define-key 'normal 'alchemist-help-minor-mode-map
     "q" 'quit-window
     "K" 'alchemist-help-search-at-point
     "m" 'alchemist-help-module
@@ -75,20 +75,20 @@
     "gd" 'alchemist-goto-definition-at-point
     "g?" 'alchemist-help-minor-mode-key-binding-summary)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-macroexpand-mode-map
+  (evil-collection-define-key 'normal 'alchemist-macroexpand-mode-map
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-refcard-mode-map
+  (evil-collection-define-key 'normal 'alchemist-refcard-mode-map
     "gd" 'alchemist-refcard--describe-funtion-at-point
     "g?" 'alchemist-refcard--describe-funtion-at-point
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-mix-mode-map
+  (evil-collection-define-key 'normal 'alchemist-mix-mode-map
     "q" 'quit-window
     "i" 'alchemist-mix-send-input-to-mix-process
     "gr" 'alchemist-mix-rerun-last-task)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-test-report-mode-map
+  (evil-collection-define-key 'normal 'alchemist-test-report-mode-map
     "q" 'quit-window
     "t" 'toggle-truncate-lines
     "gr" 'alchemist-mix-rerun-last-test
@@ -100,7 +100,7 @@
     "[" 'alchemist-test-previous-stacktrace-file
     (kbd "C-c C-k") 'alchemist-report-interrupt-current-process)
 
-  (evil-collection-define-key 'normal 'alchemist 'alchemist-mode-map
+  (evil-collection-define-key 'normal 'alchemist-mode-map
     "gz" 'alchemist-iex-run
     "K" 'alchemist-help-search-at-point
     "gd" 'alchemist-goto-definition-at-point

--- a/evil-collection-alchemist.el
+++ b/evil-collection-alchemist.el
@@ -54,19 +54,19 @@
   (evil-set-initial-state 'alchemist-test-mode 'normal)
   (evil-set-initial-state 'alchemist-test-report-mode 'normal)
 
-  (evil-define-key 'normal alchemist-compile-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-compile-mode-map
     "q" 'quit-window)
 
-  (evil-define-key 'normal alchemist-eval-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-eval-mode-map
     "q" 'quit-window)
 
-  (evil-define-key 'normal alchemist-execute-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-execute-mode-map
     "q" 'quit-window)
 
-  (evil-define-key 'normal alchemist-message-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-message-mode-map
     "q" 'quit-window)
 
-  (evil-define-key 'normal alchemist-help-minor-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-help-minor-mode-map
     "q" 'quit-window
     "K" 'alchemist-help-search-at-point
     "m" 'alchemist-help-module
@@ -75,20 +75,20 @@
     "gd" 'alchemist-goto-definition-at-point
     "g?" 'alchemist-help-minor-mode-key-binding-summary)
 
-  (evil-define-key 'normal alchemist-macroexpand-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-macroexpand-mode-map
     "q" 'quit-window)
 
-  (evil-define-key 'normal alchemist-refcard-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-refcard-mode-map
     "gd" 'alchemist-refcard--describe-funtion-at-point
     "g?" 'alchemist-refcard--describe-funtion-at-point
     "q" 'quit-window)
 
-  (evil-define-key 'normal alchemist-mix-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-mix-mode-map
     "q" 'quit-window
     "i" 'alchemist-mix-send-input-to-mix-process
     "gr" 'alchemist-mix-rerun-last-task)
 
-  (evil-define-key 'normal alchemist-test-report-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-test-report-mode-map
     "q" 'quit-window
     "t" 'toggle-truncate-lines
     "gr" 'alchemist-mix-rerun-last-test
@@ -100,7 +100,7 @@
     "[" 'alchemist-test-previous-stacktrace-file
     (kbd "C-c C-k") 'alchemist-report-interrupt-current-process)
 
-  (evil-define-key 'normal alchemist-mode-map
+  (evil-collection-define-key 'normal 'alchemist 'alchemist-mode-map
     "gz" 'alchemist-iex-run
     "K" 'alchemist-help-search-at-point
     "gd" 'alchemist-goto-definition-at-point

--- a/evil-collection-anaconda-mode.el
+++ b/evil-collection-anaconda-mode.el
@@ -39,9 +39,9 @@
 
   ;; latest anaconda uses `anaconda-view-mode-map'; anaconda stable
   ;; uses `anaconda-mode-view-mode-map'
-  (evil-define-key 'normal (if (boundp 'anaconda-mode-view-mode-map)
-                               anaconda-mode-view-mode-map
-                             anaconda-view-mode-map)
+  (evil-collection-define-key 'normal 'anaconda-mode (if (boundp 'anaconda-mode-view-mode-map)
+                                                         'anaconda-mode-view-mode-map
+                                                       'anaconda-view-mode-map)
     "gj" 'next-error-no-select
     "gk" 'previous-error-no-select
     (kbd "C-j") 'next-error-no-select
@@ -50,7 +50,7 @@
     "[" 'previous-error-no-select
     "q" 'quit-window)
 
-  (evil-define-key 'normal anaconda-mode-map
+  (evil-collection-define-key 'normal 'anaconda-mode 'anaconda-mode-map
     ;; Would be nice to support these too.
     ;; 'anaconda-mode-find-assignments
     ;; 'anaconda-mode-find-references

--- a/evil-collection-anaconda-mode.el
+++ b/evil-collection-anaconda-mode.el
@@ -39,7 +39,7 @@
 
   ;; latest anaconda uses `anaconda-view-mode-map'; anaconda stable
   ;; uses `anaconda-mode-view-mode-map'
-  (evil-collection-define-key 'normal 'anaconda-mode (if (boundp 'anaconda-mode-view-mode-map)
+  (evil-collection-define-key 'normal (if (boundp 'anaconda-mode-view-mode-map)
                                                          'anaconda-mode-view-mode-map
                                                        'anaconda-view-mode-map)
     "gj" 'next-error-no-select
@@ -50,7 +50,7 @@
     "[" 'previous-error-no-select
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'anaconda-mode 'anaconda-mode-map
+  (evil-collection-define-key 'normal 'anaconda-mode-map
     ;; Would be nice to support these too.
     ;; 'anaconda-mode-find-assignments
     ;; 'anaconda-mode-find-references

--- a/evil-collection-arc-mode.el
+++ b/evil-collection-arc-mode.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `arc-mode'."
   (evil-set-initial-state 'arc-mode 'normal)
   (evil-set-initial-state 'archive-mode 'normal)
-  (evil-collection-define-key 'normal 'arc-mode 'archive-mode-map
+  (evil-collection-define-key 'normal 'archive-mode-map
     "j" 'archive-next-line
     "k" 'archive-previous-line
     (kbd "C-j") 'archive-next-line

--- a/evil-collection-arc-mode.el
+++ b/evil-collection-arc-mode.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `arc-mode'."
   (evil-set-initial-state 'arc-mode 'normal)
   (evil-set-initial-state 'archive-mode 'normal)
-  (evil-define-key 'normal archive-mode-map
+  (evil-collection-define-key 'normal 'arc-mode 'archive-mode-map
     "j" 'archive-next-line
     "k" 'archive-previous-line
     (kbd "C-j") 'archive-next-line

--- a/evil-collection-avy.el
+++ b/evil-collection-avy.el
@@ -114,7 +114,7 @@ Based on `evil-collection-ace-jump-mode-enclose-ace-jump-for-motion'."
                      avy-goto-word-1-above
                      avy-goto-word-1-below
                      avy-goto-word-or-subword-1))
-    (define-key evil-motion-state-map
+    (evil-collection-define-key nil 'evil-motion-state-map
       (vector 'remap command) (intern-soft (format "evil-%s" command)))))
 
 (provide 'evil-collection-avy)

--- a/evil-collection-bookmark.el
+++ b/evil-collection-bookmark.el
@@ -35,7 +35,7 @@
   "Set up `evil' bindings for `bookmark'."
   (evil-set-initial-state 'bookmark-bmenu-mode 'normal)
 
-  (evil-collection-define-key 'normal 'bookmark 'bookmark-bmenu-mode-map
+  (evil-collection-define-key 'normal 'bookmark-bmenu-mode-map
     "q" 'quit-window
     "gr" 'revert-buffer
     "g?" 'describe-mode

--- a/evil-collection-bookmark.el
+++ b/evil-collection-bookmark.el
@@ -35,7 +35,7 @@
   "Set up `evil' bindings for `bookmark'."
   (evil-set-initial-state 'bookmark-bmenu-mode 'normal)
 
-  (evil-define-key 'normal bookmark-bmenu-mode-map
+  (evil-collection-define-key 'normal 'bookmark 'bookmark-bmenu-mode-map
     "q" 'quit-window
     "gr" 'revert-buffer
     "g?" 'describe-mode

--- a/evil-collection-buff-menu.el
+++ b/evil-collection-buff-menu.el
@@ -73,7 +73,7 @@ When called interactively prompt for MARK;  RET remove all marks."
   (evil-set-initial-state 'Buffer-menu-mode 'normal)
   (evil-add-hjkl-bindings Buffer-menu-mode-map 'normal)
 
-  (evil-collection-define-key 'normal 'buf-menu 'Buffer-menu-mode-map
+  (evil-collection-define-key 'normal 'Buffer-menu-mode-map
     "ZQ" 'evil-quit
     "ZZ" 'quit-window
     "gr" 'revert-buffer

--- a/evil-collection-buff-menu.el
+++ b/evil-collection-buff-menu.el
@@ -73,7 +73,7 @@ When called interactively prompt for MARK;  RET remove all marks."
   (evil-set-initial-state 'Buffer-menu-mode 'normal)
   (evil-add-hjkl-bindings Buffer-menu-mode-map 'normal)
 
-  (evil-define-key 'normal Buffer-menu-mode-map
+  (evil-collection-define-key 'normal 'buf-menu 'Buffer-menu-mode-map
     "ZQ" 'evil-quit
     "ZZ" 'quit-window
     "gr" 'revert-buffer

--- a/evil-collection-calc.el
+++ b/evil-collection-calc.el
@@ -33,7 +33,7 @@
 
 (defun evil-collection-calc-setup ()
   "Set up `evil' bindings for `calc'."
-  (evil-collection-util-inhibit-insert-state calc-mode-map)
+  (evil-collection-util-inhibit-insert-state calc calc-mode-map)
   (evil-set-initial-state 'calc-mode 'normal)
 
   ;; Calc sets up its bindings just-in-time for its "extensions".  I don't think
@@ -41,7 +41,7 @@
   ;; while making the bindings much harder to maintain.
   (require 'calc-ext)
 
-  (evil-define-key 'normal calc-mode-map
+  (evil-collection-define-key 'normal 'calc 'calc-mode-map
     "0" 'calcDigit-start
     "1" 'calcDigit-start
     "2" 'calcDigit-start
@@ -166,7 +166,7 @@
     ;; "ZZ" 'quit-window ; TODO: Rebind "Z"?
     "q" 'calc-quit)
 
-  (evil-define-key 'visual calc-mode-map
+  (evil-collection-define-key 'visual 'calc 'calc-mode-map
     "d" 'calc-kill-region))
 
 (provide 'evil-collection-calc)

--- a/evil-collection-calc.el
+++ b/evil-collection-calc.el
@@ -33,7 +33,7 @@
 
 (defun evil-collection-calc-setup ()
   "Set up `evil' bindings for `calc'."
-  (evil-collection-util-inhibit-insert-state calc calc-mode-map)
+  (evil-collection-util-inhibit-insert-state calc-mode-map)
   (evil-set-initial-state 'calc-mode 'normal)
 
   ;; Calc sets up its bindings just-in-time for its "extensions".  I don't think
@@ -41,7 +41,7 @@
   ;; while making the bindings much harder to maintain.
   (require 'calc-ext)
 
-  (evil-collection-define-key 'normal 'calc 'calc-mode-map
+  (evil-collection-define-key 'normal 'calc-mode-map
     "0" 'calcDigit-start
     "1" 'calcDigit-start
     "2" 'calcDigit-start
@@ -166,7 +166,7 @@
     ;; "ZZ" 'quit-window ; TODO: Rebind "Z"?
     "q" 'calc-quit)
 
-  (evil-collection-define-key 'visual 'calc 'calc-mode-map
+  (evil-collection-define-key 'visual 'calc-mode-map
     "d" 'calc-kill-region))
 
 (provide 'evil-collection-calc)

--- a/evil-collection-calendar.el
+++ b/evil-collection-calendar.el
@@ -35,7 +35,7 @@
 (defun evil-collection-calendar-setup ()
   "Set up `evil' bindings for `calendar'."
   (evil-set-initial-state 'calendar-mode 'normal)
-  (evil-collection-define-key 'normal 'calendar 'calendar-mode-map
+  (evil-collection-define-key 'normal 'calendar-mode-map
     ;; motion
     "h" 'calendar-backward-day
     "j" 'calendar-forward-week

--- a/evil-collection-calendar.el
+++ b/evil-collection-calendar.el
@@ -35,7 +35,7 @@
 (defun evil-collection-calendar-setup ()
   "Set up `evil' bindings for `calendar'."
   (evil-set-initial-state 'calendar-mode 'normal)
-  (evil-define-key 'normal calendar-mode-map
+  (evil-collection-define-key 'normal 'calendar 'calendar-mode-map
     ;; motion
     "h" 'calendar-backward-day
     "j" 'calendar-forward-week

--- a/evil-collection-cider.el
+++ b/evil-collection-cider.el
@@ -91,11 +91,11 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
   (when evil-collection-settings-setup-debugger-keys
     (add-hook 'cider-mode-hook #'evil-normalize-keymaps)
     (add-hook 'cider--debug-mode-hook #'evil-normalize-keymaps)
-    (evil-define-key 'normal cider-mode-map
+    (evil-collection-define-key 'normal 'cider 'cider-mode-map
       [f6] 'cider-browse-instrumented-defs
       [f9] 'cider-debug-defun-at-point)
 
-    (evil-define-key 'normal cider--debug-mode-map
+    (evil-collection-define-key 'normal 'cider 'cider--debug-mode-map
       "b" 'cider-debug-defun-at-point
       "n" 'evil-collection-cider-debug-next
       "c" 'evil-collection-cider-debug-continue
@@ -107,14 +107,14 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
       "L" 'evil-collection-cider-debug-locals
       "H" 'cider-debug-move-here))
 
-  (evil-define-key '(normal visual) cider-mode-map
+  (evil-collection-define-key '(normal visual) 'cider 'cider-mode-map
     "gd" 'cider-find-var
     (kbd "C-t") 'cider-pop-back
     "gz" 'cider-switch-to-repl-buffer
     "gf" 'cider-find-resource
     "K" 'cider-doc)
 
-  (evil-define-key '(normal visual) cider-repl-mode-map
+  (evil-collection-define-key '(normal visual) 'cider 'cider-repl-mode-map
     ;; FIXME: This seems to get overwritten by `cider-switch-to-repl-buffer'.
     "gz" 'cider-switch-to-last-clojure-buffer
 
@@ -124,7 +124,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "gf" 'cider-find-resource
     "K" 'cider-doc)
 
-  (evil-define-key 'normal cider-test-report-mode-map
+  (evil-collection-define-key 'normal 'cider 'cider-test-report-mode-map
     (kbd "C-c ,") 'cider-test-commands-map
     (kbd "C-c C-t") 'cider-test-commands-map
     (kbd "M-p") 'cider-test-previous-result
@@ -146,7 +146,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "gr" 'cider-test-run-test
     "q" 'cider-popup-buffer-quit-function)
 
-  (evil-define-key 'normal cider-macroexpansion-mode-map
+  (evil-collection-define-key 'normal 'cider 'cider-macroexpansion-mode-map
     ;; quit
     "q" 'cider-popup-buffer-quit-function
 
@@ -159,7 +159,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "u" 'cider-macroexpand-undo
     [remap undo] 'cider-macroexpand-undo)
 
-  (evil-define-key 'normal cider-connections-buffer-mode-map
+  (evil-collection-define-key 'normal 'cider 'cider-connections-buffer-mode-map
     "d" 'cider-connections-make-default
     "c" 'cider-connection-browser
     "x" 'cider-connections-close-connection
@@ -167,7 +167,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "g?" 'describe-mode)
 
   (evil-set-initial-state 'cider-stacktrace-mode 'normal)
-  (evil-define-key 'normal cider-stacktrace-mode-map
+  (evil-collection-define-key 'normal 'cider 'cider-stacktrace-mode-map
     (kbd "C-k") 'cider-stacktrace-previous-cause
     (kbd "C-j") 'cider-stacktrace-next-cause
     (kbd "gk") 'cider-stacktrace-previous-cause
@@ -193,7 +193,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     [backtab] 'cider-stacktrace-cycle-all-causes)
 
   (add-hook 'cider-inspector-mode-hook #'evil-normalize-keymaps)
-  (evil-define-key 'normal cider-inspector-mode-map
+  (evil-collection-define-key 'normal 'cider 'cider-inspector-mode-map
     "q" 'quit-window
     (kbd "RET") 'cider-inspector-operate-on-point
     [mouse-1] 'cider-inspector-operate-on-click

--- a/evil-collection-cider.el
+++ b/evil-collection-cider.el
@@ -91,11 +91,11 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
   (when evil-collection-settings-setup-debugger-keys
     (add-hook 'cider-mode-hook #'evil-normalize-keymaps)
     (add-hook 'cider--debug-mode-hook #'evil-normalize-keymaps)
-    (evil-collection-define-key 'normal 'cider 'cider-mode-map
+    (evil-collection-define-key 'normal 'cider-mode-map
       [f6] 'cider-browse-instrumented-defs
       [f9] 'cider-debug-defun-at-point)
 
-    (evil-collection-define-key 'normal 'cider 'cider--debug-mode-map
+    (evil-collection-define-key 'normal 'cider--debug-mode-map
       "b" 'cider-debug-defun-at-point
       "n" 'evil-collection-cider-debug-next
       "c" 'evil-collection-cider-debug-continue
@@ -107,14 +107,14 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
       "L" 'evil-collection-cider-debug-locals
       "H" 'cider-debug-move-here))
 
-  (evil-collection-define-key '(normal visual) 'cider 'cider-mode-map
+  (evil-collection-define-key '(normal visual) 'cider-mode-map
     "gd" 'cider-find-var
     (kbd "C-t") 'cider-pop-back
     "gz" 'cider-switch-to-repl-buffer
     "gf" 'cider-find-resource
     "K" 'cider-doc)
 
-  (evil-collection-define-key '(normal visual) 'cider 'cider-repl-mode-map
+  (evil-collection-define-key '(normal visual) 'cider-repl-mode-map
     ;; FIXME: This seems to get overwritten by `cider-switch-to-repl-buffer'.
     "gz" 'cider-switch-to-last-clojure-buffer
 
@@ -124,7 +124,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "gf" 'cider-find-resource
     "K" 'cider-doc)
 
-  (evil-collection-define-key 'normal 'cider 'cider-test-report-mode-map
+  (evil-collection-define-key 'normal 'cider-test-report-mode-map
     (kbd "C-c ,") 'cider-test-commands-map
     (kbd "C-c C-t") 'cider-test-commands-map
     (kbd "M-p") 'cider-test-previous-result
@@ -146,7 +146,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "gr" 'cider-test-run-test
     "q" 'cider-popup-buffer-quit-function)
 
-  (evil-collection-define-key 'normal 'cider 'cider-macroexpansion-mode-map
+  (evil-collection-define-key 'normal 'cider-macroexpansion-mode-map
     ;; quit
     "q" 'cider-popup-buffer-quit-function
 
@@ -159,7 +159,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "u" 'cider-macroexpand-undo
     [remap undo] 'cider-macroexpand-undo)
 
-  (evil-collection-define-key 'normal 'cider 'cider-connections-buffer-mode-map
+  (evil-collection-define-key 'normal 'cider-connections-buffer-mode-map
     "d" 'cider-connections-make-default
     "c" 'cider-connection-browser
     "x" 'cider-connections-close-connection
@@ -167,7 +167,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "g?" 'describe-mode)
 
   (evil-set-initial-state 'cider-stacktrace-mode 'normal)
-  (evil-collection-define-key 'normal 'cider 'cider-stacktrace-mode-map
+  (evil-collection-define-key 'normal 'cider-stacktrace-mode-map
     (kbd "C-k") 'cider-stacktrace-previous-cause
     (kbd "C-j") 'cider-stacktrace-next-cause
     (kbd "gk") 'cider-stacktrace-previous-cause
@@ -193,7 +193,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     [backtab] 'cider-stacktrace-cycle-all-causes)
 
   (add-hook 'cider-inspector-mode-hook #'evil-normalize-keymaps)
-  (evil-collection-define-key 'normal 'cider 'cider-inspector-mode-map
+  (evil-collection-define-key 'normal 'cider-inspector-mode-map
     "q" 'quit-window
     (kbd "RET") 'cider-inspector-operate-on-point
     [mouse-1] 'cider-inspector-operate-on-click

--- a/evil-collection-comint.el
+++ b/evil-collection-comint.el
@@ -35,10 +35,10 @@
 (defun evil-collection-comint-setup ()
   "Set up `evil' bindings for `comint'."
   (when evil-want-C-d-scroll
-    (evil-collection-define-key 'normal 'comint 'comint-mode-map
+    (evil-collection-define-key 'normal 'comint-mode-map
       (kbd "C-d") #'evil-scroll-down))
 
-  (evil-collection-define-key 'normal 'comint 'comint-mode-map
+  (evil-collection-define-key 'normal 'comint-mode-map
     (kbd "C-j") #'comint-next-input
     (kbd "C-k") #'comint-previous-input
     (kbd "gj") #'comint-next-input
@@ -46,7 +46,7 @@
     (kbd "]") #'comint-next-input
     (kbd "[") #'comint-previous-input)
 
-  (evil-collection-define-key 'insert 'comint 'comint-mode-map
+  (evil-collection-define-key 'insert 'comint-mode-map
     (kbd "<up>") #'comint-previous-input
     (kbd "<down>") #'comint-next-input))
 

--- a/evil-collection-comint.el
+++ b/evil-collection-comint.el
@@ -35,10 +35,10 @@
 (defun evil-collection-comint-setup ()
   "Set up `evil' bindings for `comint'."
   (when evil-want-C-d-scroll
-    (evil-define-key 'normal comint-mode-map
+    (evil-collection-define-key 'normal 'comint 'comint-mode-map
       (kbd "C-d") #'evil-scroll-down))
 
-  (evil-define-key 'normal comint-mode-map
+  (evil-collection-define-key 'normal 'comint 'comint-mode-map
     (kbd "C-j") #'comint-next-input
     (kbd "C-k") #'comint-previous-input
     (kbd "gj") #'comint-next-input
@@ -46,7 +46,7 @@
     (kbd "]") #'comint-next-input
     (kbd "[") #'comint-previous-input)
 
-  (evil-define-key 'insert comint-mode-map
+  (evil-collection-define-key 'insert 'comint 'comint-mode-map
     (kbd "<up>") #'comint-previous-input
     (kbd "<down>") #'comint-next-input))
 

--- a/evil-collection-company.el
+++ b/evil-collection-company.el
@@ -54,24 +54,26 @@ be set through custom or before evil-collection loads."
 
 (defun evil-collection-company-setup ()
   "Set up `evil' bindings for `company'."
-  (define-key company-active-map (kbd "C-n") 'company-select-next-or-abort)
-  (define-key company-active-map (kbd "C-p") 'company-select-previous-or-abort)
-  (define-key company-active-map (kbd "C-j") 'company-select-next-or-abort)
-  (define-key company-active-map (kbd "C-k") 'company-select-previous-or-abort)
-  (define-key company-active-map (kbd "M-j") 'company-select-next)
-  (define-key company-active-map (kbd "M-k") 'company-select-previous)
+  (evil-collection-define-key nil 'company-active-map
+    (kbd "C-n") 'company-select-next-or-abort
+    (kbd "C-p") 'company-select-previous-or-abort
+    (kbd "C-j") 'company-select-next-or-abort
+    (kbd "C-k") 'company-select-previous-or-abort
+    (kbd "M-j") 'company-select-next
+    (kbd "M-k") 'company-select-previous)
 
   (when evil-want-C-u-scroll
-    (define-key company-active-map (kbd "C-u") 'company-previous-page))
+    (evil-collection-define-key nil 'company-active-map (kbd "C-u") 'company-previous-page))
 
   (when evil-want-C-d-scroll
-    (define-key company-active-map (kbd "C-d") 'company-next-page))
+    (evil-collection-define-key nil 'company-active-map (kbd "C-d") 'company-next-page))
 
-  (define-key company-search-map (kbd "C-j") 'company-select-next-or-abort)
-  (define-key company-search-map (kbd "C-k") 'company-select-previous-or-abort)
-  (define-key company-search-map (kbd "M-j") 'company-select-next)
-  (define-key company-search-map (kbd "M-k") 'company-select-previous)
-  (define-key company-search-map (kbd "<escape>") 'company-search-abort)
+  (evil-collection-define-key nil 'company-search-map
+    (kbd "C-j") 'company-select-next-or-abort
+    (kbd "C-k") 'company-select-previous-or-abort
+    (kbd "M-j") 'company-select-next
+    (kbd "M-k") 'company-select-previous
+    (kbd "<escape>") 'company-search-abort)
 
   ;; Sets up YCMD like behavior.
   (when evil-collection-company-use-tng (company-tng-configure-default)))

--- a/evil-collection-compile.el
+++ b/evil-collection-compile.el
@@ -37,7 +37,7 @@
   "Set up `evil' bindings for `compile'."
   (evil-set-initial-state 'compilation-mode 'normal)
 
-  (evil-define-key 'normal compilation-mode-map
+  (evil-collection-define-key 'normal 'compile 'compilation-mode-map
     "g?" 'describe-mode
     "?" evil-collection-evil-search-backward
     "gg" 'evil-goto-first-line

--- a/evil-collection-compile.el
+++ b/evil-collection-compile.el
@@ -37,7 +37,7 @@
   "Set up `evil' bindings for `compile'."
   (evil-set-initial-state 'compilation-mode 'normal)
 
-  (evil-collection-define-key 'normal 'compile 'compilation-mode-map
+  (evil-collection-define-key 'normal 'compilation-mode-map
     "g?" 'describe-mode
     "?" evil-collection-evil-search-backward
     "gg" 'evil-goto-first-line

--- a/evil-collection-cus-theme.el
+++ b/evil-collection-cus-theme.el
@@ -38,7 +38,7 @@
   (evil-set-initial-state 'custom-new-theme-mode 'normal)
   (evil-set-initial-state 'custom-theme-choose-mode 'normal)
 
-  (evil-collection-define-key 'normal 'cus-theme 'custom-theme-choose-mode-map
+  (evil-collection-define-key 'normal 'custom-theme-choose-mode-map
     "gj" 'widget-forward
     "gk" 'widget-backward
     (kbd "]") 'widget-forward
@@ -47,7 +47,7 @@
     (kbd "C-k") 'widget-backward
     "K" 'custom-describe-theme)
 
-  (evil-collection-define-key 'normal 'cus-theme 'custom-new-theme-mode-map
+  (evil-collection-define-key 'normal 'custom-new-theme-mode-map
     "gj" 'widget-forward
     "gk" 'widget-backward
     (kbd "]") 'widget-forward

--- a/evil-collection-cus-theme.el
+++ b/evil-collection-cus-theme.el
@@ -38,7 +38,7 @@
   (evil-set-initial-state 'custom-new-theme-mode 'normal)
   (evil-set-initial-state 'custom-theme-choose-mode 'normal)
 
-  (evil-define-key 'normal custom-theme-choose-mode-map
+  (evil-collection-define-key 'normal 'cus-theme 'custom-theme-choose-mode-map
     "gj" 'widget-forward
     "gk" 'widget-backward
     (kbd "]") 'widget-forward
@@ -47,7 +47,7 @@
     (kbd "C-k") 'widget-backward
     "K" 'custom-describe-theme)
 
-  (evil-define-key 'normal custom-new-theme-mode-map
+  (evil-collection-define-key 'normal 'cus-theme 'custom-new-theme-mode-map
     "gj" 'widget-forward
     "gk" 'widget-backward
     (kbd "]") 'widget-forward

--- a/evil-collection-custom.el
+++ b/evil-collection-custom.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `Custom-mode'."
   (evil-set-initial-state 'Custom-mode 'normal)
 
-  (evil-collection-define-key 'normal 'cus-edit 'custom-mode-map
+  (evil-collection-define-key 'normal 'custom-mode-map
     ;; motion
     (kbd "<tab>") 'widget-forward
     (kbd "S-<tab>") 'widget-backward

--- a/evil-collection-custom.el
+++ b/evil-collection-custom.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `Custom-mode'."
   (evil-set-initial-state 'Custom-mode 'normal)
 
-  (evil-define-key 'normal custom-mode-map
+  (evil-collection-define-key 'normal 'cus-edit 'custom-mode-map
     ;; motion
     (kbd "<tab>") 'widget-forward
     (kbd "S-<tab>") 'widget-backward

--- a/evil-collection-daemons.el
+++ b/evil-collection-daemons.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-daemons-setup ()
   "Set up `evil' bindings for `daemons'."
-  (evil-define-key '(normal visual) daemons-mode-map
+  (evil-collection-define-key '(normal visual) 'daemons 'daemons-mode-map
     (kbd "RET") #'daemons-status-at-point
     "s" #'daemons-start-at-point
     "S" #'daemons-stop-at-point
@@ -49,7 +49,7 @@
     "ZQ" #'quit-window)
 
   ;; Functions are available in daemons-output-mode-map as well
-  (evil-define-key '(normal visual) daemons-output-mode-map
+  (evil-collection-define-key '(normal visual) 'daemons 'daemons-output-mode-map
     (kbd "RET") #'daemons-status-at-point
     "s" #'daemons-start-at-point
     "S" #'daemons-stop-at-point

--- a/evil-collection-daemons.el
+++ b/evil-collection-daemons.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-daemons-setup ()
   "Set up `evil' bindings for `daemons'."
-  (evil-collection-define-key '(normal visual) 'daemons 'daemons-mode-map
+  (evil-collection-define-key '(normal visual) 'daemons-mode-map
     (kbd "RET") #'daemons-status-at-point
     "s" #'daemons-start-at-point
     "S" #'daemons-stop-at-point
@@ -49,7 +49,7 @@
     "ZQ" #'quit-window)
 
   ;; Functions are available in daemons-output-mode-map as well
-  (evil-collection-define-key '(normal visual) 'daemons 'daemons-output-mode-map
+  (evil-collection-define-key '(normal visual) 'daemons-output-mode-map
     (kbd "RET") #'daemons-status-at-point
     "s" #'daemons-start-at-point
     "S" #'daemons-stop-at-point

--- a/evil-collection-debbugs.el
+++ b/evil-collection-debbugs.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `debbugs-gnu-mode'."
   (evil-set-initial-state 'debbugs-gnu-mode 'normal)
 
-  (evil-collection-define-key 'normal 'debbugs 'debbugs-gnu-mode-map
+  (evil-collection-define-key 'normal 'debbugs-gnu-mode-map
     ;; motion
     (kbd "<tab>") 'forward-button
     (kbd "<backtab>") 'backward-button

--- a/evil-collection-debbugs.el
+++ b/evil-collection-debbugs.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `debbugs-gnu-mode'."
   (evil-set-initial-state 'debbugs-gnu-mode 'normal)
 
-  (evil-define-key 'normal debbugs-gnu-mode-map
+  (evil-collection-define-key 'normal 'debbugs 'debbugs-gnu-mode-map
     ;; motion
     (kbd "<tab>") 'forward-button
     (kbd "<backtab>") 'backward-button

--- a/evil-collection-debug.el
+++ b/evil-collection-debug.el
@@ -37,7 +37,7 @@
   "Set up `evil' bindings for `debug'."
   (evil-set-initial-state 'debugger-mode 'normal)
 
-  (evil-define-key 'normal debugger-mode-map
+  (evil-collection-define-key 'normal 'debug 'debugger-mode-map
     ;; motion
     (kbd "<tab>") 'forward-button
     (kbd "S-<tab>") 'backward-button

--- a/evil-collection-debug.el
+++ b/evil-collection-debug.el
@@ -37,7 +37,7 @@
   "Set up `evil' bindings for `debug'."
   (evil-set-initial-state 'debugger-mode 'normal)
 
-  (evil-collection-define-key 'normal 'debug 'debugger-mode-map
+  (evil-collection-define-key 'normal 'debugger-mode-map
     ;; motion
     (kbd "<tab>") 'forward-button
     (kbd "S-<tab>") 'backward-button

--- a/evil-collection-diff-mode.el
+++ b/evil-collection-diff-mode.el
@@ -87,7 +87,7 @@ current file instead."
 
   (evil-set-initial-state 'diff-mode 'motion)
 
-  (evil-define-key 'normal diff-mode-map
+  (evil-collection-define-key 'normal 'diff-mode 'diff-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
@@ -100,7 +100,7 @@ current file instead."
 
     "\\" 'read-only-mode) ; magit has "\"
 
-  (evil-define-key 'motion diff-mode-map
+  (evil-collection-define-key 'motion 'diff-mode 'diff-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-diff-mode.el
+++ b/evil-collection-diff-mode.el
@@ -87,7 +87,7 @@ current file instead."
 
   (evil-set-initial-state 'diff-mode 'motion)
 
-  (evil-collection-define-key 'normal 'diff-mode 'diff-mode-map
+  (evil-collection-define-key 'normal 'diff-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
@@ -100,7 +100,7 @@ current file instead."
 
     "\\" 'read-only-mode) ; magit has "\"
 
-  (evil-collection-define-key 'motion 'diff-mode 'diff-mode-map
+  (evil-collection-define-key 'motion 'diff-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-dired.el
+++ b/evil-collection-dired.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-dired-setup ()
   "Set up `evil' bindings for `dired'."
-  (evil-collection-define-key 'normal 'dired 'dired-mode-map
+  (evil-collection-define-key 'normal 'dired-mode-map
     "q" 'quit-window
     "j" 'dired-next-line
     "k" 'dired-previous-line

--- a/evil-collection-dired.el
+++ b/evil-collection-dired.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-dired-setup ()
   "Set up `evil' bindings for `dired'."
-  (evil-define-key 'normal dired-mode-map
+  (evil-collection-define-key 'normal 'dired 'dired-mode-map
     "q" 'quit-window
     "j" 'dired-next-line
     "k" 'dired-previous-line

--- a/evil-collection-doc-view.el
+++ b/evil-collection-doc-view.el
@@ -35,7 +35,7 @@
 (defun evil-collection-doc-view-setup ()
   "Set up `evil' bindings for `doc-view'."
   (evil-set-initial-state 'doc-view-mode 'normal)
-  (evil-define-key 'normal doc-view-mode-map
+  (evil-collection-define-key 'normal 'doc-view 'doc-view-mode-map
     "q" 'quit-window
     (kbd "C-j") 'doc-view-next-page
     (kbd "C-k") 'doc-view-previous-page
@@ -76,7 +76,7 @@
 
   ;; TODO: What if the user changes `evil-want-C-u-scroll' after this is run?
   (when evil-want-C-u-scroll
-    (evil-define-key 'normal doc-view-mode-map
+    (evil-collection-define-key 'normal 'doc-view 'doc-view-mode-map
       (kbd "C-u") 'backward-page)))
 
 (provide 'evil-collection-doc-view)

--- a/evil-collection-doc-view.el
+++ b/evil-collection-doc-view.el
@@ -35,7 +35,7 @@
 (defun evil-collection-doc-view-setup ()
   "Set up `evil' bindings for `doc-view'."
   (evil-set-initial-state 'doc-view-mode 'normal)
-  (evil-collection-define-key 'normal 'doc-view 'doc-view-mode-map
+  (evil-collection-define-key 'normal 'doc-view-mode-map
     "q" 'quit-window
     (kbd "C-j") 'doc-view-next-page
     (kbd "C-k") 'doc-view-previous-page
@@ -76,7 +76,7 @@
 
   ;; TODO: What if the user changes `evil-want-C-u-scroll' after this is run?
   (when evil-want-C-u-scroll
-    (evil-collection-define-key 'normal 'doc-view 'doc-view-mode-map
+    (evil-collection-define-key 'normal 'doc-view-mode-map
       (kbd "C-u") 'backward-page)))
 
 (provide 'evil-collection-doc-view)

--- a/evil-collection-edebug.el
+++ b/evil-collection-edebug.el
@@ -46,7 +46,7 @@
 
   ;; FIXME: Seems like other minor modes will readily clash with `edebug'.
   ;; `lispyville' and `edebug' 's' key?
-  (evil-collection-define-key 'normal 'edebug 'edebug-mode-map
+  (evil-collection-define-key 'normal 'edebug-mode-map
     ;; control
     "s" 'edebug-step-mode
     "n" 'edebug-next-mode
@@ -108,12 +108,12 @@
     (kbd "C-c C-l") 'edebug-where)
 
   (with-eval-after-load 'edebug-x
-    (evil-collection-define-key 'normal 'edebug 'edebug-x-instrumented-function-list-mode-map
+    (evil-collection-define-key 'normal 'edebug-x-instrumented-function-list-mode-map
       "E" 'edebug-x-evaluate-function
       "Q" 'edebug-x-clear-data
       (kbd "<return>") 'edebug-x-find-function
       "q" 'quit-window)
-    (evil-collection-define-key 'normal 'edebug 'edebug-x-breakpoint-list-mode-map
+    (evil-collection-define-key 'normal 'edebug-x-breakpoint-list-mode-map
       (kbd "<return>") 'edebug-x-visit-breakpoint
       "x" 'edebug-x-kill-breakpoint
       "Q" 'edebug-x-clear-data

--- a/evil-collection-edebug.el
+++ b/evil-collection-edebug.el
@@ -46,7 +46,7 @@
 
   ;; FIXME: Seems like other minor modes will readily clash with `edebug'.
   ;; `lispyville' and `edebug' 's' key?
-  (evil-define-key 'normal edebug-mode-map
+  (evil-collection-define-key 'normal 'edebug 'edebug-mode-map
     ;; control
     "s" 'edebug-step-mode
     "n" 'edebug-next-mode
@@ -108,12 +108,12 @@
     (kbd "C-c C-l") 'edebug-where)
 
   (with-eval-after-load 'edebug-x
-    (evil-define-key 'normal edebug-x-instrumented-function-list-mode-map
+    (evil-collection-define-key 'normal 'edebug 'edebug-x-instrumented-function-list-mode-map
       "E" 'edebug-x-evaluate-function
       "Q" 'edebug-x-clear-data
       (kbd "<return>") 'edebug-x-find-function
       "q" 'quit-window)
-    (evil-define-key 'normal edebug-x-breakpoint-list-mode-map
+    (evil-collection-define-key 'normal 'edebug 'edebug-x-breakpoint-list-mode-map
       (kbd "<return>") 'edebug-x-visit-breakpoint
       "x" 'edebug-x-kill-breakpoint
       "Q" 'edebug-x-clear-data

--- a/evil-collection-edebug.el
+++ b/evil-collection-edebug.el
@@ -41,8 +41,9 @@
 
   (add-hook 'edebug-mode-hook #'evil-normalize-keymaps)
 
-  (define-key edebug-mode-map "g" nil)
-  (define-key edebug-mode-map "G" nil)
+  (evil-collection-define-key nil 'edebug-mode-map
+    "g" nil
+    "G" nil)
 
   ;; FIXME: Seems like other minor modes will readily clash with `edebug'.
   ;; `lispyville' and `edebug' 's' key?

--- a/evil-collection-elfeed.el
+++ b/evil-collection-elfeed.el
@@ -39,9 +39,9 @@
 (defun evil-collection-elfeed-setup ()
   "Set up `evil' bindings for `elfeed'."
 
-  (evil-collection-util-inhibit-insert-state elfeed elfeed-search-mode-map)
+  (evil-collection-util-inhibit-insert-state elfeed-search-mode-map)
   (evil-set-initial-state 'elfeed-search-mode 'normal)
-  (evil-collection-define-key 'normal 'elfeed 'elfeed-search-mode-map
+  (evil-collection-define-key 'normal 'elfeed-search-mode-map
     ;; open
     (kbd "<return>") 'elfeed-search-show-entry
     (kbd "S-<return>") 'elfeed-search-browse-url
@@ -65,15 +65,15 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-define-key '(normal visual) 'elfeed 'elfeed-search-mode-map
+  (evil-collection-define-key '(normal visual) 'elfeed-search-mode-map
     "+" 'elfeed-search-tag-all
     "-" 'elfeed-search-untag-all
     "U" 'elfeed-search-tag-all-unread
     "u" 'elfeed-search-untag-all-unread)
 
-  (evil-collection-util-inhibit-insert-state elfeed elfeed-show-mode-map)
+  (evil-collection-util-inhibit-insert-state elfeed-show-mode-map)
   (evil-set-initial-state 'elfeed-show-mode 'normal)
-  (evil-collection-define-key 'normal 'elfeed 'elfeed-show-mode-map
+  (evil-collection-define-key 'normal 'elfeed-show-mode-map
     (kbd "S-<return>") 'elfeed-show-visit
     "go" 'elfeed-show-visit
 
@@ -105,7 +105,7 @@
     "ZQ" 'elfeed-kill-buffer
     "ZZ" 'elfeed-kill-buffer)
 
-  (evil-collection-define-key 'operator 'elfeed 'elfeed-show-mode-map
+  (evil-collection-define-key 'operator 'elfeed-show-mode-map
     ;; Like `eww'.
     "u" '(menu-item
           ""

--- a/evil-collection-elfeed.el
+++ b/evil-collection-elfeed.el
@@ -39,9 +39,9 @@
 (defun evil-collection-elfeed-setup ()
   "Set up `evil' bindings for `elfeed'."
 
-  (evil-collection-util-inhibit-insert-state elfeed-search-mode-map)
+  (evil-collection-util-inhibit-insert-state elfeed elfeed-search-mode-map)
   (evil-set-initial-state 'elfeed-search-mode 'normal)
-  (evil-define-key 'normal elfeed-search-mode-map
+  (evil-collection-define-key 'normal 'elfeed 'elfeed-search-mode-map
     ;; open
     (kbd "<return>") 'elfeed-search-show-entry
     (kbd "S-<return>") 'elfeed-search-browse-url
@@ -65,15 +65,15 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-define-key '(normal visual) elfeed-search-mode-map
+  (evil-collection-define-key '(normal visual) 'elfeed 'elfeed-search-mode-map
     "+" 'elfeed-search-tag-all
     "-" 'elfeed-search-untag-all
     "U" 'elfeed-search-tag-all-unread
     "u" 'elfeed-search-untag-all-unread)
 
-  (evil-collection-util-inhibit-insert-state elfeed-show-mode-map)
+  (evil-collection-util-inhibit-insert-state elfeed elfeed-show-mode-map)
   (evil-set-initial-state 'elfeed-show-mode 'normal)
-  (evil-define-key 'normal elfeed-show-mode-map
+  (evil-collection-define-key 'normal 'elfeed 'elfeed-show-mode-map
     (kbd "S-<return>") 'elfeed-show-visit
     "go" 'elfeed-show-visit
 
@@ -105,7 +105,7 @@
     "ZQ" 'elfeed-kill-buffer
     "ZZ" 'elfeed-kill-buffer)
 
-  (evil-define-key 'operator elfeed-show-mode-map
+  (evil-collection-define-key 'operator 'elfeed 'elfeed-show-mode-map
     ;; Like `eww'.
     "u" '(menu-item
           ""

--- a/evil-collection-elisp-mode.el
+++ b/evil-collection-elisp-mode.el
@@ -38,10 +38,11 @@ BEG and END are the start and end of the output in current-buffer.
 VALUE is the Lisp value printed, ALT1 and ALT2 are strings for the
 alternative printed representations that can be displayed."
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-m")
-      'evil-collection-elisp-mode-return-or-last-sexp-toggle-display)
-    (define-key map [down-mouse-2] 'mouse-set-point)
-    (define-key map [mouse-2] 'elisp-last-sexp-toggle-display)
+    (evil-collection-define-key nil map
+      (kbd "C-m")
+      'evil-collection-elisp-mode-return-or-last-sexp-toggle-display
+      [down-mouse-2] 'mouse-set-point
+      [mouse-2] 'elisp-last-sexp-toggle-display)
     (add-text-properties
      beg end
      `(printed-value (,value ,alt1 ,alt2)

--- a/evil-collection-elisp-refs.el
+++ b/evil-collection-elisp-refs.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-elisp-refs-setup ()
   "Set up `evil' bindings for `elisp-refs'."
-  (evil-collection-define-key 'normal 'elisp-refs 'elisp-refs-mode-map
+  (evil-collection-define-key 'normal 'elisp-refs-mode-map
     (kbd "<tab>") 'elisp-refs-next-match
     (kbd "<backtab>") 'elisp-refs-prev-match
     (kbd "C-j") 'elisp-refs-next-match

--- a/evil-collection-elisp-refs.el
+++ b/evil-collection-elisp-refs.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-elisp-refs-setup ()
   "Set up `evil' bindings for `elisp-refs'."
-  (evil-define-key 'normal elisp-refs-mode-map
+  (evil-collection-define-key 'normal 'elisp-refs 'elisp-refs-mode-map
     (kbd "<tab>") 'elisp-refs-next-match
     (kbd "<backtab>") 'elisp-refs-prev-match
     (kbd "C-j") 'elisp-refs-next-match

--- a/evil-collection-emms.el
+++ b/evil-collection-emms.el
@@ -73,9 +73,9 @@ The return value is the yanked text."
   "Set up `evil' bindings for `emms-browser'."
   ;; TODO: Why doesn't evil-set-initial-state work with emms-browser-mode?
 
-  (evil-collection-util-inhibit-insert-state emms emms-browser-mode-map)
+  (evil-collection-util-inhibit-insert-state emms-browser-mode-map)
   (add-hook 'emms-browser-mode-hook 'evil-normal-state)
-  (evil-collection-define-key 'normal 'emms 'emms-browser-mode-map
+  (evil-collection-define-key 'normal 'emms-browser-mode-map
     ;; playback controls
     "x" 'emms-pause
     "X" 'emms-stop
@@ -144,7 +144,7 @@ The return value is the yanked text."
     (evil-collection-emms-browser-setup))
 
   (evil-set-initial-state 'emms-playlist-mode 'normal)
-  (evil-collection-define-key 'normal 'emms 'emms-playlist-mode-map
+  (evil-collection-define-key 'normal 'emms-playlist-mode-map
     ;; playback controls
     "x" 'emms-pause
     "X" 'emms-stop
@@ -197,15 +197,15 @@ The return value is the yanked text."
 
     (kbd "M-y") 'emms-playlist-mode-yank-pop)
 
-  (evil-collection-define-key 'visual 'emms 'emms-playlist-mode-map
+  (evil-collection-define-key 'visual 'emms-playlist-mode-map
     ;; "d" 'emms-playlist-mode-kill
     "D" 'emms-playlist-mode-kill)
 
-  (evil-collection-define-key 'normal 'emms 'emms-browser-search-mode-map
+  (evil-collection-define-key 'normal 'emms-browser-search-mode-map
     "q" 'emms-browser-kill-search)
 
   (evil-set-initial-state 'emms-metaplaylist-mode 'normal)
-  (evil-collection-define-key 'normal 'emms 'emms-metaplaylist-mode-map
+  (evil-collection-define-key 'normal 'emms-metaplaylist-mode-map
     (kbd "<return>") 'emms-metaplaylist-mode-goto-current
     (kbd "<space>") 'emms-metaplaylist-mode-set-active
     "gr" 'emms-metaplaylist-mode-update

--- a/evil-collection-emms.el
+++ b/evil-collection-emms.el
@@ -73,9 +73,9 @@ The return value is the yanked text."
   "Set up `evil' bindings for `emms-browser'."
   ;; TODO: Why doesn't evil-set-initial-state work with emms-browser-mode?
 
-  (evil-collection-util-inhibit-insert-state emms-browser-mode-map)
+  (evil-collection-util-inhibit-insert-state emms emms-browser-mode-map)
   (add-hook 'emms-browser-mode-hook 'evil-normal-state)
-  (evil-define-key 'normal emms-browser-mode-map
+  (evil-collection-define-key 'normal 'emms 'emms-browser-mode-map
     ;; playback controls
     "x" 'emms-pause
     "X" 'emms-stop
@@ -144,7 +144,7 @@ The return value is the yanked text."
     (evil-collection-emms-browser-setup))
 
   (evil-set-initial-state 'emms-playlist-mode 'normal)
-  (evil-define-key 'normal emms-playlist-mode-map
+  (evil-collection-define-key 'normal 'emms 'emms-playlist-mode-map
     ;; playback controls
     "x" 'emms-pause
     "X" 'emms-stop
@@ -197,15 +197,15 @@ The return value is the yanked text."
 
     (kbd "M-y") 'emms-playlist-mode-yank-pop)
 
-  (evil-define-key 'visual emms-playlist-mode-map
+  (evil-collection-define-key 'visual 'emms 'emms-playlist-mode-map
     ;; "d" 'emms-playlist-mode-kill
     "D" 'emms-playlist-mode-kill)
 
-  (evil-define-key 'normal emms-browser-search-mode-map
+  (evil-collection-define-key 'normal 'emms 'emms-browser-search-mode-map
     "q" 'emms-browser-kill-search)
 
   (evil-set-initial-state 'emms-metaplaylist-mode 'normal)
-  (evil-define-key 'normal emms-metaplaylist-mode-map
+  (evil-collection-define-key 'normal 'emms 'emms-metaplaylist-mode-map
     (kbd "<return>") 'emms-metaplaylist-mode-goto-current
     (kbd "<space>") 'emms-metaplaylist-mode-set-active
     "gr" 'emms-metaplaylist-mode-update

--- a/evil-collection-epa.el
+++ b/evil-collection-epa.el
@@ -36,7 +36,7 @@
                                      epa-info-mode-map))
 
 (defun evil-collection-epa-setup ()
-  (evil-collection-define-key 'normal 'epa 'epa-key-list-mode-map
+  (evil-collection-define-key 'normal 'epa-key-list-mode-map
     (kbd "<tab>") 'widget-forward
     "gr" 'revert-buffer
     "q" 'epa-exit-buffer
@@ -56,12 +56,12 @@
     "i" 'epa-import-keys
     "o" 'epa-export-keys)
 
-  (evil-collection-define-key 'normal 'epa 'epa-key-mode-map
+  (evil-collection-define-key 'normal 'epa-key-mode-map
     "q" 'epa-exit-buffer
     "ZZ" 'quit-window
     "ZQ" 'evil-quit)
 
-  (evil-collection-define-key 'normal 'epa 'epa-info-mode-map
+  (evil-collection-define-key 'normal 'epa-info-mode-map
     "q" 'delete-window
     "ZZ" 'quit-window
     "ZQ" 'evil-quit))

--- a/evil-collection-epa.el
+++ b/evil-collection-epa.el
@@ -36,7 +36,7 @@
                                      epa-info-mode-map))
 
 (defun evil-collection-epa-setup ()
-  (evil-define-key 'normal epa-key-list-mode-map
+  (evil-collection-define-key 'normal 'epa 'epa-key-list-mode-map
     (kbd "<tab>") 'widget-forward
     "gr" 'revert-buffer
     "q" 'epa-exit-buffer
@@ -56,12 +56,12 @@
     "i" 'epa-import-keys
     "o" 'epa-export-keys)
 
-  (evil-define-key 'normal epa-key-mode-map
+  (evil-collection-define-key 'normal 'epa 'epa-key-mode-map
     "q" 'epa-exit-buffer
     "ZZ" 'quit-window
     "ZQ" 'evil-quit)
 
-  (evil-define-key 'normal epa-info-mode-map
+  (evil-collection-define-key 'normal 'epa 'epa-info-mode-map
     "q" 'delete-window
     "ZZ" 'quit-window
     "ZQ" 'evil-quit))

--- a/evil-collection-ert.el
+++ b/evil-collection-ert.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `ert'."
   (evil-set-initial-state 'ert-results-mode 'normal)
 
-  (evil-define-key 'normal ert-results-mode-map
+  (evil-collection-define-key 'normal 'ert 'ert-results-mode-map
     "j" 'evil-next-line
     "k" 'evil-previous-line
     "h" 'evil-backward-char

--- a/evil-collection-ert.el
+++ b/evil-collection-ert.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `ert'."
   (evil-set-initial-state 'ert-results-mode 'normal)
 
-  (evil-collection-define-key 'normal 'ert 'ert-results-mode-map
+  (evil-collection-define-key 'normal 'ert-results-mode-map
     "j" 'evil-next-line
     "k" 'evil-previous-line
     "h" 'evil-backward-char

--- a/evil-collection-eshell.el
+++ b/evil-collection-eshell.el
@@ -55,7 +55,7 @@
 ;;; need to add bindings to `eshell-first-time-mode-hook'.
 (defun evil-collection-eshell-setup-keys ()
   "Set up `evil' bindings for `eshell'."
-  (evil-define-key 'normal eshell-mode-map
+  (evil-collection-define-key 'normal 'eshell 'eshell-mode-map
     ;; motion
     "[" 'eshell-previous-prompt
     "]" 'eshell-next-prompt
@@ -70,11 +70,11 @@
 
     (kbd "<return>") 'eshell-send-input
     (kbd "C-c C-c") 'evil-collection-eshell-interrupt-process)
-  (evil-define-key 'insert eshell-mode-map
+  (evil-collection-define-key 'insert 'eshell 'eshell-mode-map
     ;; motion
     (kbd "M-h") 'eshell-backward-argument
     (kbd "M-l") 'eshell-forward-argument)
-  (evil-define-key 'visual eshell-mode-map
+  (evil-collection-define-key 'visual 'eshell 'eshell-mode-map
     ;; motion
     ;; TODO: This does not work with `evil-visual-line'.
     "[" 'eshell-previous-prompt

--- a/evil-collection-eshell.el
+++ b/evil-collection-eshell.el
@@ -55,7 +55,7 @@
 ;;; need to add bindings to `eshell-first-time-mode-hook'.
 (defun evil-collection-eshell-setup-keys ()
   "Set up `evil' bindings for `eshell'."
-  (evil-collection-define-key 'normal 'eshell 'eshell-mode-map
+  (evil-collection-define-key 'normal 'eshell-mode-map
     ;; motion
     "[" 'eshell-previous-prompt
     "]" 'eshell-next-prompt
@@ -70,11 +70,11 @@
 
     (kbd "<return>") 'eshell-send-input
     (kbd "C-c C-c") 'evil-collection-eshell-interrupt-process)
-  (evil-collection-define-key 'insert 'eshell 'eshell-mode-map
+  (evil-collection-define-key 'insert 'eshell-mode-map
     ;; motion
     (kbd "M-h") 'eshell-backward-argument
     (kbd "M-l") 'eshell-forward-argument)
-  (evil-collection-define-key 'visual 'eshell 'eshell-mode-map
+  (evil-collection-define-key 'visual 'eshell-mode-map
     ;; motion
     ;; TODO: This does not work with `evil-visual-line'.
     "[" 'eshell-previous-prompt

--- a/evil-collection-etags-select.el
+++ b/evil-collection-etags-select.el
@@ -32,7 +32,8 @@
 (defun evil-collection-etags-select-setup ()
   "Set up `evil' bindings for `etags-select'.."
   ;; FIXME: probably etags-select should be recomended in docs
-  (define-key evil-motion-state-map "g]" 'etags-select-find-tag-at-point))
+  (evil-collection-define-key nil 'evil-motion-state-map
+    "g]" 'etags-select-find-tag-at-point))
 
 (provide 'evil-collection-etags-select)
 ;;; evil-collection-etags-select.el ends here

--- a/evil-collection-eww.el
+++ b/evil-collection-eww.el
@@ -38,7 +38,7 @@
 (defun evil-collection-eww-setup ()
   "Set up `evil' bindings for `eww'."
 
-  (evil-collection-define-key 'normal 'eww 'eww-mode-map
+  (evil-collection-define-key 'normal 'eww-mode-map
     "^" 'eww-up-url
     "u" 'eww-up-url
     "U" 'eww-top-url
@@ -87,7 +87,7 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-define-key 'operator 'eww 'eww-mode-map
+  (evil-collection-define-key 'operator 'eww-mode-map
     "u" '(menu-item
           ""
           nil
@@ -97,9 +97,9 @@
                       (setq evil-inhibit-operator t)
                       #'eww-copy-page-url))))
 
-  (evil-collection-util-inhibit-insert-state eww eww-history-mode-map)
+  (evil-collection-util-inhibit-insert-state eww-history-mode-map)
   (evil-set-initial-state 'eww-history-mode 'normal)
-  (evil-collection-define-key 'normal 'eww 'eww-history-mode-map
+  (evil-collection-define-key 'normal 'eww-history-mode-map
     (kbd "<return>") 'eww-history-browse
     ;; refresh
     "gr" 'revert-buffer
@@ -108,9 +108,9 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state eww eww-buffers-mode-map)
+  (evil-collection-util-inhibit-insert-state eww-buffers-mode-map)
   (evil-set-initial-state 'eww-buffers-mode 'normal)
-  (evil-collection-define-key 'normal 'eww 'eww-buffers-mode-map
+  (evil-collection-define-key 'normal 'eww-buffers-mode-map
     "D" 'eww-buffer-kill
     (kbd "<return>") 'eww-buffer-select
     "]" 'eww-buffer-show-next
@@ -124,9 +124,9 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state eww eww-bookmark-mode-map)
+  (evil-collection-util-inhibit-insert-state eww-bookmark-mode-map)
   (evil-set-initial-state 'eww-bookmark-mode 'normal)
-  (evil-collection-define-key 'normal 'eww 'eww-bookmark-mode-map
+  (evil-collection-define-key 'normal 'eww-bookmark-mode-map
     "D" 'eww-bookmark-kill
     "P" 'eww-bookmark-yank
 
@@ -138,7 +138,7 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-define-key 'operator 'eww 'eww-bookmark-mode-map
+  (evil-collection-define-key 'operator 'eww-bookmark-mode-map
     "u" '(menu-item
           ""
           nil

--- a/evil-collection-eww.el
+++ b/evil-collection-eww.el
@@ -38,7 +38,7 @@
 (defun evil-collection-eww-setup ()
   "Set up `evil' bindings for `eww'."
 
-  (evil-define-key 'normal eww-mode-map
+  (evil-collection-define-key 'normal 'eww 'eww-mode-map
     "^" 'eww-up-url
     "u" 'eww-up-url
     "U" 'eww-top-url
@@ -87,7 +87,7 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-define-key 'operator eww-mode-map
+  (evil-collection-define-key 'operator 'eww 'eww-mode-map
     "u" '(menu-item
           ""
           nil
@@ -97,9 +97,9 @@
                       (setq evil-inhibit-operator t)
                       #'eww-copy-page-url))))
 
-  (evil-collection-util-inhibit-insert-state eww-history-mode-map)
+  (evil-collection-util-inhibit-insert-state eww eww-history-mode-map)
   (evil-set-initial-state 'eww-history-mode 'normal)
-  (evil-define-key 'normal eww-history-mode-map
+  (evil-collection-define-key 'normal 'eww 'eww-history-mode-map
     (kbd "<return>") 'eww-history-browse
     ;; refresh
     "gr" 'revert-buffer
@@ -108,9 +108,9 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state eww-buffers-mode-map)
+  (evil-collection-util-inhibit-insert-state eww eww-buffers-mode-map)
   (evil-set-initial-state 'eww-buffers-mode 'normal)
-  (evil-define-key 'normal eww-buffers-mode-map
+  (evil-collection-define-key 'normal 'eww 'eww-buffers-mode-map
     "D" 'eww-buffer-kill
     (kbd "<return>") 'eww-buffer-select
     "]" 'eww-buffer-show-next
@@ -124,9 +124,9 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state eww-bookmark-mode-map)
+  (evil-collection-util-inhibit-insert-state eww eww-bookmark-mode-map)
   (evil-set-initial-state 'eww-bookmark-mode 'normal)
-  (evil-define-key 'normal eww-bookmark-mode-map
+  (evil-collection-define-key 'normal 'eww 'eww-bookmark-mode-map
     "D" 'eww-bookmark-kill
     "P" 'eww-bookmark-yank
 
@@ -138,7 +138,7 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-define-key 'operator eww-bookmark-mode-map
+  (evil-collection-define-key 'operator 'eww 'eww-bookmark-mode-map
     "u" '(menu-item
           ""
           nil

--- a/evil-collection-flycheck.el
+++ b/evil-collection-flycheck.el
@@ -37,7 +37,7 @@
 (defun evil-collection-flycheck-setup ()
   "Set up `evil' bindings for `flycheck'."
   (evil-set-initial-state 'flycheck-error-list-mode 'normal)
-  (evil-define-key 'normal flycheck-error-list-mode-map
+  (evil-collection-define-key 'normal 'flycheck 'flycheck-error-list-mode-map
     "gj" 'flycheck-error-list-next-error
     "gk" 'flycheck-error-list-previous-error
     (kbd "C-j") 'flycheck-error-list-next-error

--- a/evil-collection-flycheck.el
+++ b/evil-collection-flycheck.el
@@ -37,7 +37,7 @@
 (defun evil-collection-flycheck-setup ()
   "Set up `evil' bindings for `flycheck'."
   (evil-set-initial-state 'flycheck-error-list-mode 'normal)
-  (evil-collection-define-key 'normal 'flycheck 'flycheck-error-list-mode-map
+  (evil-collection-define-key 'normal 'flycheck-error-list-mode-map
     "gj" 'flycheck-error-list-next-error
     "gk" 'flycheck-error-list-previous-error
     (kbd "C-j") 'flycheck-error-list-next-error

--- a/evil-collection-free-keys.el
+++ b/evil-collection-free-keys.el
@@ -43,7 +43,7 @@
   (add-hook 'free-keys-mode-hook
             #'evil-collection-free-keys-set-header-line-format)
   (evil-set-initial-state 'free-keys-mode 'normal)
-  (evil-collection-define-key 'normal 'free-keys 'free-keys-mode-map
+  (evil-collection-define-key 'normal 'free-keys-mode-map
     "c" 'free-keys-change-buffer
     "p" 'free-keys-set-prefix
     "q" 'quit-window))

--- a/evil-collection-free-keys.el
+++ b/evil-collection-free-keys.el
@@ -43,7 +43,7 @@
   (add-hook 'free-keys-mode-hook
             #'evil-collection-free-keys-set-header-line-format)
   (evil-set-initial-state 'free-keys-mode 'normal)
-  (evil-define-key 'normal free-keys-mode-map
+  (evil-collection-define-key 'normal 'free-keys 'free-keys-mode-map
     "c" 'free-keys-change-buffer
     "p" 'free-keys-set-prefix
     "q" 'quit-window))

--- a/evil-collection-geiser.el
+++ b/evil-collection-geiser.el
@@ -56,10 +56,10 @@
   (evil-set-initial-state 'geiser-debug-mode 'normal)
   (evil-set-initial-state 'geiser-doc-mode 'normal)
 
-  (evil-define-key 'normal geiser-debug-mode-map
+  (evil-collection-define-key 'normal 'geiser 'geiser-debug-mode-map
     "q" 'quit-window)
 
-  (evil-define-key 'normal geiser-doc-mode-map
+  (evil-collection-define-key 'normal 'geiser 'geiser-doc-mode-map
     (kbd "<tab>") 'forward-button
     (kbd "<S-tab>") 'backward-button
     "gd" 'geiser-edit-symbol-at-point
@@ -78,10 +78,10 @@
     "x" 'geiser-doc-kill-page
     "X" 'geiser-doc-clean-history)
 
-  (evil-define-key 'insert geiser-repl-mode-map
+  (evil-collection-define-key 'insert geiser-repl-mode-map
     (kbd "S-<return>") 'geiser-repl--newline-and-indent)
 
-  (evil-define-key 'normal geiser-repl-mode-map
+  (evil-collection-define-key 'normal 'geiser 'geiser-repl-mode-map
     "gd" 'geiser-edit-symbol-at-point
     (kbd "C-t") 'geiser-pop-symbol-stack
     "gj" 'geiser-repl-next-prompt
@@ -92,7 +92,7 @@
     "[" 'geiser-repl-previous-prompt
     "K" 'geiser-doc-symbol-at-point)
 
-  (evil-define-key 'normal geiser-mode-map
+  (evil-collection-define-key 'normal 'geiser 'geiser-mode-map
     "gd" 'geiser-edit-symbol-at-point
     (kbd "C-t") 'geiser-pop-symbol-stack
     "gZ" 'geiser-mode-switch-to-repl-and-enter

--- a/evil-collection-geiser.el
+++ b/evil-collection-geiser.el
@@ -56,10 +56,10 @@
   (evil-set-initial-state 'geiser-debug-mode 'normal)
   (evil-set-initial-state 'geiser-doc-mode 'normal)
 
-  (evil-collection-define-key 'normal 'geiser 'geiser-debug-mode-map
+  (evil-collection-define-key 'normal 'geiser-debug-mode-map
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'geiser 'geiser-doc-mode-map
+  (evil-collection-define-key 'normal 'geiser-doc-mode-map
     (kbd "<tab>") 'forward-button
     (kbd "<S-tab>") 'backward-button
     "gd" 'geiser-edit-symbol-at-point
@@ -78,10 +78,10 @@
     "x" 'geiser-doc-kill-page
     "X" 'geiser-doc-clean-history)
 
-  (evil-collection-define-key 'insert geiser-repl-mode-map
+  (evil-collection-define-key 'insert 'geiser-repl-mode-map
     (kbd "S-<return>") 'geiser-repl--newline-and-indent)
 
-  (evil-collection-define-key 'normal 'geiser 'geiser-repl-mode-map
+  (evil-collection-define-key 'normal 'geiser-repl-mode-map
     "gd" 'geiser-edit-symbol-at-point
     (kbd "C-t") 'geiser-pop-symbol-stack
     "gj" 'geiser-repl-next-prompt
@@ -92,7 +92,7 @@
     "[" 'geiser-repl-previous-prompt
     "K" 'geiser-doc-symbol-at-point)
 
-  (evil-collection-define-key 'normal 'geiser 'geiser-mode-map
+  (evil-collection-define-key 'normal 'geiser-mode-map
     "gd" 'geiser-edit-symbol-at-point
     (kbd "C-t") 'geiser-pop-symbol-stack
     "gZ" 'geiser-mode-switch-to-repl-and-enter

--- a/evil-collection-ggtags.el
+++ b/evil-collection-ggtags.el
@@ -52,12 +52,12 @@
   (when (boundp 'ggtags-enable-navigation-keys)
     (setq ggtags-enable-navigation-keys nil))
 
-  (evil-define-key 'normal ggtags-mode-map
+  (evil-collection-define-key 'normal 'ggtags 'ggtags-mode-map
     "gd" 'ggtags-find-tag-dwim
     (kbd "C-t") 'ggtags-prev-mark
     "gf" 'ggtags-find-file)
 
-  (evil-define-key 'normal ggtags-view-search-history-mode-map
+  (evil-collection-define-key 'normal 'ggtags 'ggtags-view-search-history-mode-map
     "gj" 'ggtags-view-search-history-next
     "gk" 'ggtags-view-search-history-prev
     (kbd "C-j") 'ggtags-view-search-history-next
@@ -70,7 +70,7 @@
     "R" 'ggtags-view-search-history-action
     "q" 'ggtags-kill-window)
 
-  (evil-define-key 'normal ggtags-view-tag-history-mode-map
+  (evil-collection-define-key 'normal 'ggtags 'ggtags-view-tag-history-mode-map
     "gj" 'next-error-no-select
     (kbd "C-j") 'next-error-no-select
     "]" 'next-error-no-select
@@ -79,7 +79,7 @@
     (kbd "[") 'previous-error-no-select
     "q" 'ggtags-kill-window)
 
-  (evil-define-key 'normal ggtags-navigation-map
+  (evil-collection-define-key 'normal 'ggtags 'ggtags-navigation-map
     ;; navigation
     "gj" 'next-error
     "gk" 'next-error

--- a/evil-collection-ggtags.el
+++ b/evil-collection-ggtags.el
@@ -52,12 +52,12 @@
   (when (boundp 'ggtags-enable-navigation-keys)
     (setq ggtags-enable-navigation-keys nil))
 
-  (evil-collection-define-key 'normal 'ggtags 'ggtags-mode-map
+  (evil-collection-define-key 'normal 'ggtags-mode-map
     "gd" 'ggtags-find-tag-dwim
     (kbd "C-t") 'ggtags-prev-mark
     "gf" 'ggtags-find-file)
 
-  (evil-collection-define-key 'normal 'ggtags 'ggtags-view-search-history-mode-map
+  (evil-collection-define-key 'normal 'ggtags-view-search-history-mode-map
     "gj" 'ggtags-view-search-history-next
     "gk" 'ggtags-view-search-history-prev
     (kbd "C-j") 'ggtags-view-search-history-next
@@ -70,7 +70,7 @@
     "R" 'ggtags-view-search-history-action
     "q" 'ggtags-kill-window)
 
-  (evil-collection-define-key 'normal 'ggtags 'ggtags-view-tag-history-mode-map
+  (evil-collection-define-key 'normal 'ggtags-view-tag-history-mode-map
     "gj" 'next-error-no-select
     (kbd "C-j") 'next-error-no-select
     "]" 'next-error-no-select
@@ -79,7 +79,7 @@
     (kbd "[") 'previous-error-no-select
     "q" 'ggtags-kill-window)
 
-  (evil-collection-define-key 'normal 'ggtags 'ggtags-navigation-map
+  (evil-collection-define-key 'normal 'ggtags-navigation-map
     ;; navigation
     "gj" 'next-error
     "gk" 'next-error

--- a/evil-collection-go-mode.el
+++ b/evil-collection-go-mode.el
@@ -35,10 +35,10 @@
 
 (defun evil-collection-go-mode-setup ()
   "Set up `evil' bindings for `go-mode'."
-  (evil-collection-define-key 'normal 'go-mode 'go-mode-map
+  (evil-collection-define-key 'normal 'go-mode-map
     "gd" 'godef-jump
     "K" 'godef-describe)
-  (evil-collection-define-key 'normal 'go-mode 'godoc-mode-map
+  (evil-collection-define-key 'normal 'godoc-mode-map
     "q" 'quit-window
     "g?" 'describe-mode))
 

--- a/evil-collection-go-mode.el
+++ b/evil-collection-go-mode.el
@@ -35,10 +35,10 @@
 
 (defun evil-collection-go-mode-setup ()
   "Set up `evil' bindings for `go-mode'."
-  (evil-define-key 'normal go-mode-map
+  (evil-collection-define-key 'normal 'go-mode 'go-mode-map
     "gd" 'godef-jump
     "K" 'godef-describe)
-  (evil-define-key 'normal godoc-mode-map
+  (evil-collection-define-key 'normal 'go-mode 'godoc-mode-map
     "q" 'quit-window
     "g?" 'describe-mode))
 

--- a/evil-collection-guix.el
+++ b/evil-collection-guix.el
@@ -46,8 +46,8 @@
 (defmacro evil-collection-guix-set (map)
   "Set common bindings in MAP."
   `(progn
-     (evil-collection-util-inhibit-insert-state guix ,map)
-     (evil-collection-define-key 'normal 'guix ',map
+     (evil-collection-util-inhibit-insert-state ,map)
+     (evil-collection-define-key 'normal ',map
         ;; motion
         (kbd "SPC") 'scroll-up-command
         (kbd "S-SPC") 'scroll-down-command
@@ -88,7 +88,7 @@
   "Set up `evil' bindings for `guix'."
   (evil-collection-guix-set guix-ui-map) ; Covers output-list and generation-list.
 
-  (evil-collection-define-key 'normal 'guix 'guix-output-list-mode-map
+  (evil-collection-define-key 'normal 'guix-output-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "gb" 'guix-package-list-latest-builds
@@ -106,7 +106,7 @@
     "x" 'guix-output-list-execute)
 
   (evil-collection-guix-set guix-package-info-mode-map)
-  (evil-collection-define-key 'normal 'guix 'guix-package-info-mode-map
+  (evil-collection-define-key 'normal 'guix-package-info-mode-map
     "gG" 'guix-package-info-graph
     "gl" 'guix-package-info-lint
     "gs" 'guix-package-info-size
@@ -117,7 +117,7 @@
     "i" 'guix-package-info-install)
 
   (evil-collection-guix-set guix-profile-list-mode-map)
-  (evil-collection-define-key 'normal 'guix 'guix-profile-list-mode-map
+  (evil-collection-define-key 'normal 'guix-profile-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "c" 'guix-profile-list-set-current ; TODO: Bind to "." as per the rationale?
@@ -126,7 +126,7 @@
     "P" 'guix-profile-list-show-search-paths)
 
   (evil-collection-guix-set guix-profile-info-mode-map)
-  (evil-collection-define-key 'normal 'guix 'guix-profile-info-mode-map
+  (evil-collection-define-key 'normal 'guix-profile-info-mode-map
     "gm" 'guix-profile-info-apply-manifest
 
     "p" 'guix-profile-info-show-packages
@@ -134,7 +134,7 @@
     "P" 'guix-profile-info-show-search-paths
     "c" 'guix-profile-info-set-current)
 
-  (evil-collection-define-key 'normal 'guix 'guix-generation-list-mode-map
+  (evil-collection-define-key 'normal 'guix-generation-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "p" 'guix-generation-list-show-packages
@@ -151,7 +151,7 @@
     "x" 'guix-generation-list-execute)
 
   (evil-collection-guix-set guix-license-list-mode-map)
-  (evil-collection-define-key 'normal 'guix 'guix-license-list-mode-map
+  (evil-collection-define-key 'normal 'guix-license-list-mode-map
     (kbd "<tab>") 'forward-button       ; Why isn't this binding inhibited?
     (kbd "<return>") 'bui-list-describe
 
@@ -161,14 +161,14 @@
   (evil-collection-guix-set guix-license-info-mode-map)
 
   (evil-collection-guix-set guix-location-list-mode-map)
-  (evil-collection-define-key 'normal 'guix 'guix-location-list-mode-map
+  (evil-collection-define-key 'normal 'guix-location-list-mode-map
     (kbd "<return>") 'guix-location-list-show-packages ; In Emacs state, it seems to be overriden by `push-button'.
 
     "p" 'guix-location-list-show-packages
     "gd" 'guix-location-list-edit)
 
   (evil-collection-guix-set guix-hydra-build-list-mode-map)
-  (evil-collection-define-key 'normal 'guix 'guix-hydra-build-list-mode-map
+  (evil-collection-define-key 'normal 'guix-hydra-build-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "gb" 'guix-hydra-build-list-latest-builds
@@ -176,8 +176,8 @@
 
   (evil-collection-guix-set guix-hydra-build-info-mode-map)
 
-  (evil-collection-util-inhibit-insert-state guix guix-build-log-mode-map)
-  (evil-collection-define-key 'normal 'guix 'guix-build-log-mode-map
+  (evil-collection-util-inhibit-insert-state guix-build-log-mode-map)
+  (evil-collection-define-key 'normal 'guix-build-log-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
@@ -201,7 +201,7 @@
     "ZQ" 'evil-quit
     "ZZ" 'quit-window)
 
-  (evil-collection-define-key 'normal 'guix 'guix-devel-mode-map
+  (evil-collection-define-key 'normal 'guix-devel-mode-map
     ;; repl
     "gz" 'guix-switch-to-repl))
 

--- a/evil-collection-guix.el
+++ b/evil-collection-guix.el
@@ -46,8 +46,8 @@
 (defmacro evil-collection-guix-set (map)
   "Set common bindings in MAP."
   `(progn
-     (evil-collection-util-inhibit-insert-state ,map)
-     (evil-define-key 'normal ,map
+     (evil-collection-util-inhibit-insert-state guix ,map)
+     (evil-collection-define-key 'normal 'guix ',map
         ;; motion
         (kbd "SPC") 'scroll-up-command
         (kbd "S-SPC") 'scroll-down-command
@@ -88,7 +88,7 @@
   "Set up `evil' bindings for `guix'."
   (evil-collection-guix-set guix-ui-map) ; Covers output-list and generation-list.
 
-  (evil-define-key 'normal guix-output-list-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-output-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "gb" 'guix-package-list-latest-builds
@@ -106,7 +106,7 @@
     "x" 'guix-output-list-execute)
 
   (evil-collection-guix-set guix-package-info-mode-map)
-  (evil-define-key 'normal guix-package-info-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-package-info-mode-map
     "gG" 'guix-package-info-graph
     "gl" 'guix-package-info-lint
     "gs" 'guix-package-info-size
@@ -117,7 +117,7 @@
     "i" 'guix-package-info-install)
 
   (evil-collection-guix-set guix-profile-list-mode-map)
-  (evil-define-key 'normal guix-profile-list-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-profile-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "c" 'guix-profile-list-set-current ; TODO: Bind to "." as per the rationale?
@@ -126,7 +126,7 @@
     "P" 'guix-profile-list-show-search-paths)
 
   (evil-collection-guix-set guix-profile-info-mode-map)
-  (evil-define-key 'normal guix-profile-info-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-profile-info-mode-map
     "gm" 'guix-profile-info-apply-manifest
 
     "p" 'guix-profile-info-show-packages
@@ -134,7 +134,7 @@
     "P" 'guix-profile-info-show-search-paths
     "c" 'guix-profile-info-set-current)
 
-  (evil-define-key 'normal guix-generation-list-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-generation-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "p" 'guix-generation-list-show-packages
@@ -151,7 +151,7 @@
     "x" 'guix-generation-list-execute)
 
   (evil-collection-guix-set guix-license-list-mode-map)
-  (evil-define-key 'normal guix-license-list-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-license-list-mode-map
     (kbd "<tab>") 'forward-button       ; Why isn't this binding inhibited?
     (kbd "<return>") 'bui-list-describe
 
@@ -161,14 +161,14 @@
   (evil-collection-guix-set guix-license-info-mode-map)
 
   (evil-collection-guix-set guix-location-list-mode-map)
-  (evil-define-key 'normal guix-location-list-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-location-list-mode-map
     (kbd "<return>") 'guix-location-list-show-packages ; In Emacs state, it seems to be overriden by `push-button'.
 
     "p" 'guix-location-list-show-packages
     "gd" 'guix-location-list-edit)
 
   (evil-collection-guix-set guix-hydra-build-list-mode-map)
-  (evil-define-key 'normal guix-hydra-build-list-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-hydra-build-list-mode-map
     (kbd "<return>") 'bui-list-describe
 
     "gb" 'guix-hydra-build-list-latest-builds
@@ -176,8 +176,8 @@
 
   (evil-collection-guix-set guix-hydra-build-info-mode-map)
 
-  (evil-collection-util-inhibit-insert-state guix-build-log-mode-map)
-  (evil-define-key 'normal guix-build-log-mode-map
+  (evil-collection-util-inhibit-insert-state guix guix-build-log-mode-map)
+  (evil-collection-define-key 'normal 'guix 'guix-build-log-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
@@ -201,7 +201,7 @@
     "ZQ" 'evil-quit
     "ZZ" 'quit-window)
 
-  (evil-define-key 'normal guix-devel-mode-map
+  (evil-collection-define-key 'normal 'guix 'guix-devel-mode-map
     ;; repl
     "gz" 'guix-switch-to-repl))
 

--- a/evil-collection-helm.el
+++ b/evil-collection-helm.el
@@ -104,7 +104,7 @@
   (add-hook 'helm-minibuffer-set-up-hook 'evil-collection-helm-hide-minibuffer-maybe)
   (setq helm-default-prompt-display-function 'evil-collection-helm--set-prompt-display)
 
-  (evil-collection-define-key '(insert normal) 'helm 'helm-map
+  (evil-collection-define-key '(insert normal) 'helm-map
     (kbd "M-[") 'helm-previous-source
     (kbd "M-]") 'helm-next-source
     (kbd "M-l") 'helm-execute-persistent-action
@@ -114,38 +114,38 @@
     (kbd "C-b") 'helm-previous-page)
 
   (dolist (map (list helm-find-files-map helm-read-file-map))
-    (evil-collection-define-key* 'normal 'helm map
+    (evil-collection-define-key* 'normal map
                       "go" 'helm-ff-run-switch-other-window
                       "/" 'helm-ff-run-find-sh-command)
-    (evil-collection-define-key* '(insert normal) 'helm map
+    (evil-collection-define-key* '(insert normal) map
                       (kbd "S-<return>") 'helm-ff-run-switch-other-window
                       (kbd "M-h") 'helm-find-files-up-one-level))
 
   ;; TODO: Change the Helm header to display "M-l" instead of "C-l".  We don't
   ;; want to modify the Emacs Helm map.
 
-  (evil-collection-define-key '(insert normal) 'helm helm-generic-files-map (kbd "S-<return>") 'helm-ff-run-switch-other-window)
-  (evil-collection-define-key '(insert normal) 'helm helm-buffer-map (kbd "S-<return>") 'helm-buffer-switch-other-window)
-  (evil-collection-define-key '(insert normal) 'helm helm-buffer-map (kbd "M-<return>") 'display-buffer)
-  (evil-collection-define-key '(insert normal) 'helm helm-moccur-map (kbd "S-<return>") 'helm-moccur-run-goto-line-ow)
-  (evil-collection-define-key '(insert normal) 'helm helm-grep-map (kbd "S-<return>") 'helm-grep-run-other-window-action)
-  (evil-collection-define-key 'normal 'helm helm-generic-files-map "go" 'helm-ff-run-switch-other-window)
-  (evil-collection-define-key 'normal 'helm helm-buffer-map "go" 'helm-buffer-switch-other-window)
-  (evil-collection-define-key 'normal 'helm helm-buffer-map "gO" 'display-buffer)
-  (evil-collection-define-key 'normal 'helm helm-moccur-map "go" 'helm-moccur-run-goto-line-ow)
-  (evil-collection-define-key 'normal 'helm helm-grep-map "go" 'helm-grep-run-other-window-action)
+  (evil-collection-define-key '(insert normal) helm-generic-files-map (kbd "S-<return>") 'helm-ff-run-switch-other-window)
+  (evil-collection-define-key '(insert normal) helm-buffer-map (kbd "S-<return>") 'helm-buffer-switch-other-window)
+  (evil-collection-define-key '(insert normal) helm-buffer-map (kbd "M-<return>") 'display-buffer)
+  (evil-collection-define-key '(insert normal) helm-moccur-map (kbd "S-<return>") 'helm-moccur-run-goto-line-ow)
+  (evil-collection-define-key '(insert normal) helm-grep-map (kbd "S-<return>") 'helm-grep-run-other-window-action)
+  (evil-collection-define-key 'normal helm-generic-files-map "go" 'helm-ff-run-switch-other-window)
+  (evil-collection-define-key 'normal helm-buffer-map "go" 'helm-buffer-switch-other-window)
+  (evil-collection-define-key 'normal helm-buffer-map "gO" 'display-buffer)
+  (evil-collection-define-key 'normal helm-moccur-map "go" 'helm-moccur-run-goto-line-ow)
+  (evil-collection-define-key 'normal helm-grep-map "go" 'helm-grep-run-other-window-action)
 
-  (evil-collection-define-key 'normal 'helm helm-buffer-map
+  (evil-collection-define-key 'normal helm-buffer-map
     "=" 'helm-buffer-run-ediff
     "%" 'helm-buffer-run-query-replace-regexp
     "D" 'helm-buffer-run-kill-persistent) ; Ivy has "D".
 
-  (evil-collection-define-key 'normal 'helm helm-find-files-map
+  (evil-collection-define-key 'normal helm-find-files-map
     "=" 'helm-ff-run-ediff-file
     "%" 'helm-ff-run-query-replace-regexp
     "D" 'helm-ff-run-delete-file)       ; Ivy has "D".
 
-  (evil-collection-define-key 'normal 'helm helm-map
+  (evil-collection-define-key 'normal helm-map
     (kbd "<tab>") 'helm-select-action   ; TODO: Ivy has "ga".
     (kbd "[") 'helm-previous-source
     (kbd "]") 'helm-next-source

--- a/evil-collection-helm.el
+++ b/evil-collection-helm.el
@@ -104,7 +104,7 @@
   (add-hook 'helm-minibuffer-set-up-hook 'evil-collection-helm-hide-minibuffer-maybe)
   (setq helm-default-prompt-display-function 'evil-collection-helm--set-prompt-display)
 
-  (evil-define-key '(insert normal) helm-map
+  (evil-collection-define-key '(insert normal) 'helm 'helm-map
     (kbd "M-[") 'helm-previous-source
     (kbd "M-]") 'helm-next-source
     (kbd "M-l") 'helm-execute-persistent-action
@@ -114,38 +114,38 @@
     (kbd "C-b") 'helm-previous-page)
 
   (dolist (map (list helm-find-files-map helm-read-file-map))
-    (evil-define-key* 'normal map
+    (evil-collection-define-key* 'normal 'helm map
                       "go" 'helm-ff-run-switch-other-window
                       "/" 'helm-ff-run-find-sh-command)
-    (evil-define-key* '(insert normal) map
+    (evil-collection-define-key* '(insert normal) 'helm map
                       (kbd "S-<return>") 'helm-ff-run-switch-other-window
                       (kbd "M-h") 'helm-find-files-up-one-level))
 
   ;; TODO: Change the Helm header to display "M-l" instead of "C-l".  We don't
   ;; want to modify the Emacs Helm map.
 
-  (evil-define-key '(insert normal) helm-generic-files-map (kbd "S-<return>") 'helm-ff-run-switch-other-window)
-  (evil-define-key '(insert normal) helm-buffer-map (kbd "S-<return>") 'helm-buffer-switch-other-window)
-  (evil-define-key '(insert normal) helm-buffer-map (kbd "M-<return>") 'display-buffer)
-  (evil-define-key '(insert normal) helm-moccur-map (kbd "S-<return>") 'helm-moccur-run-goto-line-ow)
-  (evil-define-key '(insert normal) helm-grep-map (kbd "S-<return>") 'helm-grep-run-other-window-action)
-  (evil-define-key 'normal helm-generic-files-map "go" 'helm-ff-run-switch-other-window)
-  (evil-define-key 'normal helm-buffer-map "go" 'helm-buffer-switch-other-window)
-  (evil-define-key 'normal helm-buffer-map "gO" 'display-buffer)
-  (evil-define-key 'normal helm-moccur-map "go" 'helm-moccur-run-goto-line-ow)
-  (evil-define-key 'normal helm-grep-map "go" 'helm-grep-run-other-window-action)
+  (evil-collection-define-key '(insert normal) 'helm helm-generic-files-map (kbd "S-<return>") 'helm-ff-run-switch-other-window)
+  (evil-collection-define-key '(insert normal) 'helm helm-buffer-map (kbd "S-<return>") 'helm-buffer-switch-other-window)
+  (evil-collection-define-key '(insert normal) 'helm helm-buffer-map (kbd "M-<return>") 'display-buffer)
+  (evil-collection-define-key '(insert normal) 'helm helm-moccur-map (kbd "S-<return>") 'helm-moccur-run-goto-line-ow)
+  (evil-collection-define-key '(insert normal) 'helm helm-grep-map (kbd "S-<return>") 'helm-grep-run-other-window-action)
+  (evil-collection-define-key 'normal 'helm helm-generic-files-map "go" 'helm-ff-run-switch-other-window)
+  (evil-collection-define-key 'normal 'helm helm-buffer-map "go" 'helm-buffer-switch-other-window)
+  (evil-collection-define-key 'normal 'helm helm-buffer-map "gO" 'display-buffer)
+  (evil-collection-define-key 'normal 'helm helm-moccur-map "go" 'helm-moccur-run-goto-line-ow)
+  (evil-collection-define-key 'normal 'helm helm-grep-map "go" 'helm-grep-run-other-window-action)
 
-  (evil-define-key 'normal helm-buffer-map
+  (evil-collection-define-key 'normal 'helm helm-buffer-map
     "=" 'helm-buffer-run-ediff
     "%" 'helm-buffer-run-query-replace-regexp
     "D" 'helm-buffer-run-kill-persistent) ; Ivy has "D".
 
-  (evil-define-key 'normal helm-find-files-map
+  (evil-collection-define-key 'normal 'helm helm-find-files-map
     "=" 'helm-ff-run-ediff-file
     "%" 'helm-ff-run-query-replace-regexp
     "D" 'helm-ff-run-delete-file)       ; Ivy has "D".
 
-  (evil-define-key 'normal helm-map
+  (evil-collection-define-key 'normal 'helm helm-map
     (kbd "<tab>") 'helm-select-action   ; TODO: Ivy has "ga".
     (kbd "[") 'helm-previous-source
     (kbd "]") 'helm-next-source

--- a/evil-collection-help.el
+++ b/evil-collection-help.el
@@ -35,7 +35,7 @@
 (defun evil-collection-help-setup ()
   "Set up `evil' bindings for `help'."
   (evil-set-initial-state 'help-mode 'normal)
-  (evil-collection-define-key 'normal 'help-mode 'help-mode-map
+  (evil-collection-define-key 'normal 'help-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-help.el
+++ b/evil-collection-help.el
@@ -35,7 +35,7 @@
 (defun evil-collection-help-setup ()
   "Set up `evil' bindings for `help'."
   (evil-set-initial-state 'help-mode 'normal)
-  (evil-define-key 'normal help-mode-map
+  (evil-collection-define-key 'normal 'help-mode 'help-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-ibuffer.el
+++ b/evil-collection-ibuffer.el
@@ -36,12 +36,12 @@
   "Set up `evil' bindings for `ibuffer'."
   (evil-set-initial-state 'ibuffer-mode 'normal)
 
-  (evil-define-key 'normal ibuffer-mode-map
+  (evil-collection-define-key 'normal 'ibuffer 'ibuffer-mode-map
     (kbd "C-d") (if evil-want-C-d-scroll
                     'evil-scroll-down
                   'ibuffer-mark-for-delete-backwards))
 
-  (evil-define-key 'normal ibuffer-mode-map
+  (evil-collection-define-key 'normal 'ibuffer 'ibuffer-mode-map
     (kbd "=") 'ibuffer-diff-with-file
     (kbd "J") 'ibuffer-jump-to-buffer
     (kbd "M-g") 'ibuffer-jump-to-buffer

--- a/evil-collection-ibuffer.el
+++ b/evil-collection-ibuffer.el
@@ -36,12 +36,12 @@
   "Set up `evil' bindings for `ibuffer'."
   (evil-set-initial-state 'ibuffer-mode 'normal)
 
-  (evil-collection-define-key 'normal 'ibuffer 'ibuffer-mode-map
+  (evil-collection-define-key 'normal 'ibuffer-mode-map
     (kbd "C-d") (if evil-want-C-d-scroll
                     'evil-scroll-down
                   'ibuffer-mark-for-delete-backwards))
 
-  (evil-collection-define-key 'normal 'ibuffer 'ibuffer-mode-map
+  (evil-collection-define-key 'normal 'ibuffer-mode-map
     (kbd "=") 'ibuffer-diff-with-file
     (kbd "J") 'ibuffer-jump-to-buffer
     (kbd "M-g") 'ibuffer-jump-to-buffer

--- a/evil-collection-image+.el
+++ b/evil-collection-image+.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-image+-setup ()
   "Set up `evil' bindings for `image+'."
-  (evil-define-key 'normal image-mode-map
+  (evil-collection-define-key 'normal 'image+ 'image-mode-map
     ;; zoom
     "+" 'imagex-sticky-zoom-in
     "=" 'imagex-sticky-zoom-in

--- a/evil-collection-image+.el
+++ b/evil-collection-image+.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-image+-setup ()
   "Set up `evil' bindings for `image+'."
-  (evil-collection-define-key 'normal 'image+ 'image-mode-map
+  (evil-collection-define-key 'normal 'image-mode-map
     ;; zoom
     "+" 'imagex-sticky-zoom-in
     "=" 'imagex-sticky-zoom-in

--- a/evil-collection-image.el
+++ b/evil-collection-image.el
@@ -39,7 +39,7 @@
   "Set up `evil' bindings for `image-mode'."
   (evil-set-initial-state 'image-mode 'normal)
 
-  (evil-collection-define-key 'normal 'image-mode 'image-mode-map
+  (evil-collection-define-key 'normal 'image-mode-map
     ;; motion
     "gg" 'image-bob
     "G" 'image-eob
@@ -84,7 +84,7 @@
 
   ;; TODO: What if the user changes `evil-want-C-u-scroll' after this is run?
   (when evil-want-C-u-scroll
-    (evil-collection-define-key 'normal 'image-mode 'image-mode-map
+    (evil-collection-define-key 'normal 'image-mode-map
       (kbd "C-u") 'image-scroll-down)))
 
 (provide 'evil-collection-image)

--- a/evil-collection-image.el
+++ b/evil-collection-image.el
@@ -39,7 +39,7 @@
   "Set up `evil' bindings for `image-mode'."
   (evil-set-initial-state 'image-mode 'normal)
 
-  (evil-define-key 'normal image-mode-map
+  (evil-collection-define-key 'normal 'image-mode 'image-mode-map
     ;; motion
     "gg" 'image-bob
     "G" 'image-eob
@@ -84,7 +84,7 @@
 
   ;; TODO: What if the user changes `evil-want-C-u-scroll' after this is run?
   (when evil-want-C-u-scroll
-    (evil-define-key 'normal image-mode-map
+    (evil-collection-define-key 'normal 'image-mode 'image-mode-map
       (kbd "C-u") 'image-scroll-down)))
 
 (provide 'evil-collection-image)

--- a/evil-collection-indium.el
+++ b/evil-collection-indium.el
@@ -40,7 +40,7 @@
 (defun evil-collection-indium-setup ()
   "Set up `evil' bindings for `indium'."
   (when evil-collection-settings-setup-debugger-keys
-    (evil-define-key 'normal indium-debugger-mode-map
+    (evil-collection-define-key 'normal 'indium 'indium-debugger-mode-map
       "n" 'indium-debugger-step-over
       "i" 'indium-debugger-step-into
       "o" 'indium-debugger-step-out
@@ -55,7 +55,7 @@
 
     (add-hook 'indium-debugger-mode-hook #'evil-normalize-keymaps))
 
-  (evil-define-key 'normal indium-inspector-mode-map
+  (evil-collection-define-key 'normal 'indium 'indium-inspector-mode-map
     "q" 'quit-window
     (kbd "RET") 'indium-follow-link
     [mouse-1] 'indium-follow-link
@@ -68,12 +68,12 @@
     [tab] 'indium-inspector-next-reference
     [backtab] 'indium-inspector-previous-reference)
 
-  (evil-define-key 'normal indium-debugger-locals-mode-map
+  (evil-collection-define-key 'normal 'indium 'indium-debugger-locals-mode-map
     "q" 'quit-window
     "L" nil
     "gr" nil)
 
-  (evil-define-key 'normal indium-debugger-frames-mode-map
+  (evil-collection-define-key 'normal 'indium 'indium-debugger-frames-mode-map
     "q" 'quit-window
     [return] 'indium-follow-link
     (kbd "RET") 'indium-follow-link
@@ -84,12 +84,12 @@
     [tab] 'indium-debugger-frames-next-frame
     [backtab] 'indium-debugger-frames-previous-frame)
 
-  (evil-define-key 'normal indium-interaction-mode-map
+  (evil-collection-define-key 'normal 'indium 'indium-interaction-mode-map
     "gr" 'indium-update-script-source
     "gz" 'indium-switch-to-repl-buffer)
 
   (when evil-collection-settings-setup-debugger-keys
-    (evil-define-key 'normal indium-interaction-mode-map
+    (evil-collection-define-key 'normal 'indium 'indium-interaction-mode-map
       [left-fringe mouse-1] 'evil-collection-indium-debugger-mouse-toggle-breakpoint
       [left-margin mouse-1] 'evil-collection-indium-debugger-mouse-toggle-breakpoint
       [f5] 'indium-debugger-resume
@@ -99,7 +99,7 @@
       [f11] 'indium-debugger-step-into
       [S-f11] 'indium-debugger-step-out))
 
-  (evil-define-key 'normal indium-repl-mode-map
+  (evil-collection-define-key 'normal 'indium 'indium-repl-mode-map
     (kbd "gj") 'indium-repl-next-input
     (kbd "gk") 'indium-repl-previous-input
     (kbd "C-j") 'indium-repl-next-input

--- a/evil-collection-indium.el
+++ b/evil-collection-indium.el
@@ -40,7 +40,7 @@
 (defun evil-collection-indium-setup ()
   "Set up `evil' bindings for `indium'."
   (when evil-collection-settings-setup-debugger-keys
-    (evil-collection-define-key 'normal 'indium 'indium-debugger-mode-map
+    (evil-collection-define-key 'normal 'indium-debugger-mode-map
       "n" 'indium-debugger-step-over
       "i" 'indium-debugger-step-into
       "o" 'indium-debugger-step-out
@@ -55,7 +55,7 @@
 
     (add-hook 'indium-debugger-mode-hook #'evil-normalize-keymaps))
 
-  (evil-collection-define-key 'normal 'indium 'indium-inspector-mode-map
+  (evil-collection-define-key 'normal 'indium-inspector-mode-map
     "q" 'quit-window
     (kbd "RET") 'indium-follow-link
     [mouse-1] 'indium-follow-link
@@ -68,12 +68,12 @@
     [tab] 'indium-inspector-next-reference
     [backtab] 'indium-inspector-previous-reference)
 
-  (evil-collection-define-key 'normal 'indium 'indium-debugger-locals-mode-map
+  (evil-collection-define-key 'normal 'indium-debugger-locals-mode-map
     "q" 'quit-window
     "L" nil
     "gr" nil)
 
-  (evil-collection-define-key 'normal 'indium 'indium-debugger-frames-mode-map
+  (evil-collection-define-key 'normal 'indium-debugger-frames-mode-map
     "q" 'quit-window
     [return] 'indium-follow-link
     (kbd "RET") 'indium-follow-link
@@ -84,12 +84,12 @@
     [tab] 'indium-debugger-frames-next-frame
     [backtab] 'indium-debugger-frames-previous-frame)
 
-  (evil-collection-define-key 'normal 'indium 'indium-interaction-mode-map
+  (evil-collection-define-key 'normal 'indium-interaction-mode-map
     "gr" 'indium-update-script-source
     "gz" 'indium-switch-to-repl-buffer)
 
   (when evil-collection-settings-setup-debugger-keys
-    (evil-collection-define-key 'normal 'indium 'indium-interaction-mode-map
+    (evil-collection-define-key 'normal 'indium-interaction-mode-map
       [left-fringe mouse-1] 'evil-collection-indium-debugger-mouse-toggle-breakpoint
       [left-margin mouse-1] 'evil-collection-indium-debugger-mouse-toggle-breakpoint
       [f5] 'indium-debugger-resume
@@ -99,7 +99,7 @@
       [f11] 'indium-debugger-step-into
       [S-f11] 'indium-debugger-step-out))
 
-  (evil-collection-define-key 'normal 'indium 'indium-repl-mode-map
+  (evil-collection-define-key 'normal 'indium-repl-mode-map
     (kbd "gj") 'indium-repl-next-input
     (kbd "gk") 'indium-repl-previous-input
     (kbd "C-j") 'indium-repl-next-input

--- a/evil-collection-info.el
+++ b/evil-collection-info.el
@@ -36,9 +36,9 @@
 
 (defun evil-collection-info-setup ()
   "Set up `evil' bindings for `info-mode'."
-  (evil-collection-util-inhibit-insert-state Info-mode-map)
+  (evil-collection-util-inhibit-insert-state info Info-mode-map)
   (evil-set-initial-state 'Info-mode 'normal)
-  (evil-define-key 'normal Info-mode-map
+  (evil-collection-define-key 'normal 'info 'Info-mode-map
     (kbd "<tab>") 'Info-next-reference
     (kbd "S-<tab>") 'Info-prev-reference
 
@@ -97,7 +97,7 @@
     "ZQ" 'evil-quit
     "ZZ" 'Info-exit)
 
-  (evil-define-key 'operator Info-mode-map
+  (evil-collection-define-key 'operator 'info 'Info-mode-map
     "u" '(menu-item                     ; Like eww.
           ""
           nil

--- a/evil-collection-info.el
+++ b/evil-collection-info.el
@@ -36,9 +36,9 @@
 
 (defun evil-collection-info-setup ()
   "Set up `evil' bindings for `info-mode'."
-  (evil-collection-util-inhibit-insert-state info Info-mode-map)
+  (evil-collection-util-inhibit-insert-state Info-mode-map)
   (evil-set-initial-state 'Info-mode 'normal)
-  (evil-collection-define-key 'normal 'info 'Info-mode-map
+  (evil-collection-define-key 'normal 'Info-mode-map
     (kbd "<tab>") 'Info-next-reference
     (kbd "S-<tab>") 'Info-prev-reference
 
@@ -97,7 +97,7 @@
     "ZQ" 'evil-quit
     "ZZ" 'Info-exit)
 
-  (evil-collection-define-key 'operator 'info 'Info-mode-map
+  (evil-collection-define-key 'operator 'Info-mode-map
     "u" '(menu-item                     ; Like eww.
           ""
           nil

--- a/evil-collection-ivy.el
+++ b/evil-collection-ivy.el
@@ -36,9 +36,9 @@
 
 (defun evil-collection-ivy-setup ()
   "Set up `evil' bindings for `ivy-mode'."
-  (evil-collection-define-key nil 'ivy 'ivy-mode-map
+  (evil-collection-define-key nil 'ivy-mode-map
     (kbd "<escape>") 'minibuffer-keyboard-quit)
-  (evil-collection-define-key 'normal 'ivy 'ivy-occur-mode-map
+  (evil-collection-define-key 'normal 'ivy-occur-mode-map
     [mouse-1] 'ivy-occur-click
     (kbd "<return>") 'ivy-occur-press-and-switch
     "j" 'ivy-occur-next-line
@@ -59,15 +59,15 @@
     "q" 'quit-window)
 
   (when evil-want-C-d-scroll
-    (evil-collection-define-key 'normal 'ivy 'ivy-occur-grep-mode-map
+    (evil-collection-define-key 'normal 'ivy-occur-grep-mode-map
       "D" 'ivy-occur-delete-candidate
       (kbd "C-d") 'evil-scroll-down))
 
-  (evil-collection-define-key 'visual 'ivy 'ivy-occur-grep-mode-map
+  (evil-collection-define-key 'visual 'ivy-occur-grep-mode-map
     "j" 'evil-next-line
     "k" 'evil-previous-line)
 
-  (evil-collection-define-key 'normal 'ivy 'ivy-occur-grep-mode-map
+  (evil-collection-define-key 'normal 'ivy-occur-grep-mode-map
     "d" 'ivy-occur-delete-candidate
     (kbd "C-x C-q") 'ivy-wgrep-change-to-wgrep-mode
     "i" 'ivy-wgrep-change-to-wgrep-mode
@@ -91,14 +91,14 @@
 
   (defvar evil-collection-setup-minibuffer)
   (when evil-collection-setup-minibuffer
-    (evil-collection-define-key 'normal 'ivy 'ivy-minibuffer-map
+    (evil-collection-define-key 'normal 'ivy-minibuffer-map
       (kbd "<escape>") 'abort-recursive-edit
       (kbd "<return>") 'exit-minibuffer
       (kbd "C-m") 'ivy-done
       "j" 'ivy-next-line
       "k" 'ivy-previous-line)
 
-    (evil-collection-define-key 'insert 'ivy 'ivy-minibuffer-map
+    (evil-collection-define-key 'insert 'ivy-minibuffer-map
       [backspace] 'ivy-backward-delete-char
       (kbd "C-r") 'ivy-reverse-i-search
       (kbd "C-n") 'ivy-next-line

--- a/evil-collection-ivy.el
+++ b/evil-collection-ivy.el
@@ -36,8 +36,9 @@
 
 (defun evil-collection-ivy-setup ()
   "Set up `evil' bindings for `ivy-mode'."
-  (evil-define-key nil ivy-mode-map (kbd "<escape>") 'minibuffer-keyboard-quit)
-  (evil-define-key 'normal ivy-occur-mode-map
+  (evil-collection-define-key nil 'ivy 'ivy-mode-map
+    (kbd "<escape>") 'minibuffer-keyboard-quit)
+  (evil-collection-define-key 'normal 'ivy 'ivy-occur-mode-map
     [mouse-1] 'ivy-occur-click
     (kbd "<return>") 'ivy-occur-press-and-switch
     "j" 'ivy-occur-next-line
@@ -58,15 +59,15 @@
     "q" 'quit-window)
 
   (when evil-want-C-d-scroll
-    (evil-define-key 'normal ivy-occur-grep-mode-map
+    (evil-collection-define-key 'normal 'ivy 'ivy-occur-grep-mode-map
       "D" 'ivy-occur-delete-candidate
       (kbd "C-d") 'evil-scroll-down))
 
-  (evil-define-key 'visual ivy-occur-grep-mode-map
+  (evil-collection-define-key 'visual 'ivy 'ivy-occur-grep-mode-map
     "j" 'evil-next-line
     "k" 'evil-previous-line)
 
-  (evil-define-key 'normal ivy-occur-grep-mode-map
+  (evil-collection-define-key 'normal 'ivy 'ivy-occur-grep-mode-map
     "d" 'ivy-occur-delete-candidate
     (kbd "C-x C-q") 'ivy-wgrep-change-to-wgrep-mode
     "i" 'ivy-wgrep-change-to-wgrep-mode
@@ -90,14 +91,14 @@
 
   (defvar evil-collection-setup-minibuffer)
   (when evil-collection-setup-minibuffer
-    (evil-define-key 'normal ivy-minibuffer-map
+    (evil-collection-define-key 'normal 'ivy 'ivy-minibuffer-map
       (kbd "<escape>") 'abort-recursive-edit
       (kbd "<return>") 'exit-minibuffer
       (kbd "C-m") 'ivy-done
       "j" 'ivy-next-line
       "k" 'ivy-previous-line)
 
-    (evil-define-key 'insert ivy-minibuffer-map
+    (evil-collection-define-key 'insert 'ivy 'ivy-minibuffer-map
       [backspace] 'ivy-backward-delete-char
       (kbd "C-r") 'ivy-reverse-i-search
       (kbd "C-n") 'ivy-next-line

--- a/evil-collection-kotlin-mode.el
+++ b/evil-collection-kotlin-mode.el
@@ -34,7 +34,8 @@
 
 (defun evil-collection-kotlin-mode-setup ()
   "Set up `evil' bindings for `kotlin-mode'."
-  (evil-define-key 'normal kotlin-mode-map "gz" 'kotlin-repl))
+  (evil-collection-define-key 'normal 'kotlin-mode 'kotlin-mode-map
+    "gz" 'kotlin-repl))
 
 (provide 'evil-collection-kotlin-mode)
 ;;; evil-collection-kotlin-mode.el ends here

--- a/evil-collection-kotlin-mode.el
+++ b/evil-collection-kotlin-mode.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-kotlin-mode-setup ()
   "Set up `evil' bindings for `kotlin-mode'."
-  (evil-collection-define-key 'normal 'kotlin-mode 'kotlin-mode-map
+  (evil-collection-define-key 'normal 'kotlin-mode-map
     "gz" 'kotlin-repl))
 
 (provide 'evil-collection-kotlin-mode)

--- a/evil-collection-log-view.el
+++ b/evil-collection-log-view.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-log-view-setup ()
   "Set up `evil' bindings for `log-view'."
-  (evil-define-key 'normal log-view-mode-map
+  (evil-collection-define-key 'normal 'log-view 'log-view-mode-map
     "q" 'quit-window
     (kbd "RET") 'log-view-toggle-entry-display
     "m" 'log-view-toggle-mark-entry

--- a/evil-collection-log-view.el
+++ b/evil-collection-log-view.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-log-view-setup ()
   "Set up `evil' bindings for `log-view'."
-  (evil-collection-define-key 'normal 'log-view 'log-view-mode-map
+  (evil-collection-define-key 'normal 'log-view-mode-map
     "q" 'quit-window
     (kbd "RET") 'log-view-toggle-entry-display
     "m" 'log-view-toggle-mark-entry

--- a/evil-collection-lsp-ui-imenu.el
+++ b/evil-collection-lsp-ui-imenu.el
@@ -35,7 +35,7 @@
 (defun evil-collection-lsp-ui-imenu-setup ()
   "Set up `evil' bindings for `lsp-ui-imenu'."
   (evil-set-initial-state 'lsp-ui-imenu-mode 'normal)
-  (evil-define-key 'normal lsp-ui-imenu-mode-map
+  (evil-collection-define-key 'normal 'lsp-ui 'lsp-ui-imenu-mode-map
     (kbd "l") 'lsp-ui-imenu--prev-kind
     (kbd "h") 'lsp-ui-imenu--next-kind
     (kbd "q") 'lsp-ui-imenu--kill

--- a/evil-collection-lsp-ui-imenu.el
+++ b/evil-collection-lsp-ui-imenu.el
@@ -35,7 +35,7 @@
 (defun evil-collection-lsp-ui-imenu-setup ()
   "Set up `evil' bindings for `lsp-ui-imenu'."
   (evil-set-initial-state 'lsp-ui-imenu-mode 'normal)
-  (evil-collection-define-key 'normal 'lsp-ui 'lsp-ui-imenu-mode-map
+  (evil-collection-define-key 'normal 'lsp-ui-imenu-mode-map
     (kbd "l") 'lsp-ui-imenu--prev-kind
     (kbd "h") 'lsp-ui-imenu--next-kind
     (kbd "q") 'lsp-ui-imenu--kill

--- a/evil-collection-lua-mode.el
+++ b/evil-collection-lua-mode.el
@@ -42,7 +42,7 @@
   "Set up `evil' bindings for `lua-mode'."
   (add-hook 'lua-mode-hook #'evil-collection-lua-mode-set-evil-shift-width)
 
-  (evil-collection-define-key 'normal 'lua-mode 'lua-mode-map
+  (evil-collection-define-key 'normal 'lua-mode-map
     "K" 'lua-search-documentation))
 
 (provide 'evil-collection-lua-mode)

--- a/evil-collection-lua-mode.el
+++ b/evil-collection-lua-mode.el
@@ -42,7 +42,7 @@
   "Set up `evil' bindings for `lua-mode'."
   (add-hook 'lua-mode-hook #'evil-collection-lua-mode-set-evil-shift-width)
 
-  (evil-define-key 'normal lua-mode-map
+  (evil-collection-define-key 'normal 'lua-mode 'lua-mode-map
     "K" 'lua-search-documentation))
 
 (provide 'evil-collection-lua-mode)

--- a/evil-collection-macrostep.el
+++ b/evil-collection-macrostep.el
@@ -38,7 +38,7 @@
   ;; Force `evil' to normalize keymaps.
   (add-hook 'macrostep-mode-hook #'evil-normalize-keymaps)
 
-  (evil-define-key 'normal macrostep-keymap
+  (evil-collection-define-key 'normal 'macrostep 'macrostep-keymap
     "q" 'macrostep-collapse-all
     "e" 'macrostep-expand
     "u" 'macrostep-collapse

--- a/evil-collection-macrostep.el
+++ b/evil-collection-macrostep.el
@@ -38,7 +38,7 @@
   ;; Force `evil' to normalize keymaps.
   (add-hook 'macrostep-mode-hook #'evil-normalize-keymaps)
 
-  (evil-collection-define-key 'normal 'macrostep 'macrostep-keymap
+  (evil-collection-define-key 'normal 'macrostep-keymap
     "q" 'macrostep-collapse-all
     "e" 'macrostep-expand
     "u" 'macrostep-collapse

--- a/evil-collection-magit.el
+++ b/evil-collection-magit.el
@@ -40,7 +40,7 @@
 
 (defun evil-collection-magit-setup ()
   "Set up `evil' bindings for `magit'."
-  (evil-define-key 'normal magit-blame-mode-map
+  (evil-collection-define-key 'normal 'magit 'magit-blame-mode-map
     "q" 'magit-blame-quit))
 
 (provide 'evil-collection-magit)

--- a/evil-collection-magit.el
+++ b/evil-collection-magit.el
@@ -40,7 +40,7 @@
 
 (defun evil-collection-magit-setup ()
   "Set up `evil' bindings for `magit'."
-  (evil-collection-define-key 'normal 'magit 'magit-blame-mode-map
+  (evil-collection-define-key 'normal 'magit-blame-mode-map
     "q" 'magit-blame-quit))
 
 (provide 'evil-collection-magit)

--- a/evil-collection-man.el
+++ b/evil-collection-man.el
@@ -35,7 +35,7 @@
 (defun evil-collection-man-setup ()
   "Set up `evil' bindings for `man'."
   (evil-set-initial-state 'Man-mode 'normal)
-  (evil-define-key 'normal Man-mode-map
+  (evil-collection-define-key 'normal 'man 'Man-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-man.el
+++ b/evil-collection-man.el
@@ -35,7 +35,7 @@
 (defun evil-collection-man-setup ()
   "Set up `evil' bindings for `man'."
   (evil-set-initial-state 'Man-mode 'normal)
-  (evil-collection-define-key 'normal 'man 'Man-mode-map
+  (evil-collection-define-key 'normal 'Man-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-minibuffer.el
+++ b/evil-collection-minibuffer.el
@@ -55,24 +55,21 @@ it does not have a mode."
 (defun evil-collection-minibuffer-setup ()
   "Initialize minibuffer for `evil'."
   ;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Text-from-Minibuffer.html
-  ;; WARNING: With lexical binding, lambdas from `mapc' and `dolist' become
-  ;; closures in which we must use `evil-define-key*' instead of
-  ;; `evil-define-key'.
   (dolist (map (list minibuffer-local-map
                      minibuffer-local-ns-map
                      minibuffer-local-completion-map
                      minibuffer-local-must-match-map
                      minibuffer-local-isearch-map))
-    (evil-define-key* 'normal map (kbd "<escape>") 'abort-recursive-edit)
-    (evil-define-key* 'normal map (kbd "<return>") 'exit-minibuffer))
+    (evil-collection-define-key 'normal 'minibuffer map (kbd "<escape>") 'abort-recursive-edit)
+    (evil-collection-define-key 'normal 'minibuffer map (kbd "<return>") 'exit-minibuffer))
 
   (add-hook 'minibuffer-setup-hook 'evil-collection-minibuffer-insert)
   ;; Because of the above minibuffer-setup-hook, some evil-ex bindings need be reset.
-  (evil-define-key 'normal evil-ex-completion-map (kbd "<escape>") 'abort-recursive-edit)
-  (evil-define-key 'insert evil-ex-completion-map (kbd "C-p") 'previous-complete-history-element)
-  (evil-define-key 'insert evil-ex-completion-map (kbd "C-n") 'next-complete-history-element)
-  (evil-define-key 'normal evil-ex-completion-map (kbd "C-p") 'previous-history-element)
-  (evil-define-key 'normal evil-ex-completion-map (kbd "C-n") 'next-history-element))
+  (evil-collection-define-key 'normal 'minibuffer evil-ex-completion-map (kbd "<escape>") 'abort-recursive-edit)
+  (evil-collection-define-key 'insert 'minibuffer evil-ex-completion-map (kbd "C-p") 'previous-complete-history-element)
+  (evil-collection-define-key 'insert 'minibuffer evil-ex-completion-map (kbd "C-n") 'next-complete-history-element)
+  (evil-collection-define-key 'normal 'minibuffer evil-ex-completion-map (kbd "C-p") 'previous-history-element)
+  (evil-collection-define-key 'normal 'minibuffer evil-ex-completion-map (kbd "C-n") 'next-history-element))
 
 (provide 'evil-collection-minibuffer)
 ;;; evil-collection-minibuffer.el ends here

--- a/evil-collection-minibuffer.el
+++ b/evil-collection-minibuffer.el
@@ -60,16 +60,16 @@ it does not have a mode."
                      minibuffer-local-completion-map
                      minibuffer-local-must-match-map
                      minibuffer-local-isearch-map))
-    (evil-collection-define-key 'normal 'minibuffer map (kbd "<escape>") 'abort-recursive-edit)
-    (evil-collection-define-key 'normal 'minibuffer map (kbd "<return>") 'exit-minibuffer))
+    (evil-collection-define-key 'normal map (kbd "<escape>") 'abort-recursive-edit)
+    (evil-collection-define-key 'normal map (kbd "<return>") 'exit-minibuffer))
 
   (add-hook 'minibuffer-setup-hook 'evil-collection-minibuffer-insert)
   ;; Because of the above minibuffer-setup-hook, some evil-ex bindings need be reset.
-  (evil-collection-define-key 'normal 'minibuffer evil-ex-completion-map (kbd "<escape>") 'abort-recursive-edit)
-  (evil-collection-define-key 'insert 'minibuffer evil-ex-completion-map (kbd "C-p") 'previous-complete-history-element)
-  (evil-collection-define-key 'insert 'minibuffer evil-ex-completion-map (kbd "C-n") 'next-complete-history-element)
-  (evil-collection-define-key 'normal 'minibuffer evil-ex-completion-map (kbd "C-p") 'previous-history-element)
-  (evil-collection-define-key 'normal 'minibuffer evil-ex-completion-map (kbd "C-n") 'next-history-element))
+  (evil-collection-define-key 'normal 'evil-ex-completion-map (kbd "<escape>") 'abort-recursive-edit)
+  (evil-collection-define-key 'insert 'evil-ex-completion-map (kbd "C-p") 'previous-complete-history-element)
+  (evil-collection-define-key 'insert 'evil-ex-completion-map (kbd "C-n") 'next-complete-history-element)
+  (evil-collection-define-key 'normal 'evil-ex-completion-map (kbd "C-p") 'previous-history-element)
+  (evil-collection-define-key 'normal 'evil-ex-completion-map (kbd "C-n") 'next-history-element))
 
 (provide 'evil-collection-minibuffer)
 ;;; evil-collection-minibuffer.el ends here

--- a/evil-collection-neotree.el
+++ b/evil-collection-neotree.el
@@ -38,7 +38,7 @@
 
   (evil-set-initial-state 'neotree-mode 'normal) ;; Neotree start in normal by default.
 
-  (evil-define-key 'normal neotree-mode-map
+  (evil-collection-define-key 'normal 'neotree 'neotree-mode-map
 
     (kbd "<return>") (neotree-make-executor
                       :file-fn 'neo-open-file

--- a/evil-collection-neotree.el
+++ b/evil-collection-neotree.el
@@ -38,7 +38,7 @@
 
   (evil-set-initial-state 'neotree-mode 'normal) ;; Neotree start in normal by default.
 
-  (evil-collection-define-key 'normal 'neotree 'neotree-mode-map
+  (evil-collection-define-key 'normal 'neotree-mode-map
 
     (kbd "<return>") (neotree-make-executor
                       :file-fn 'neo-open-file

--- a/evil-collection-notmuch.el
+++ b/evil-collection-notmuch.el
@@ -74,7 +74,7 @@
   (evil-set-initial-state 'notmuch-search-mode 'normal)
   (evil-set-initial-state 'notmuch-hello-mode 'normal)
 
-  (evil-define-key 'normal notmuch-common-keymap
+  (evil-collection-define-key 'normal 'notmuch 'notmuch-common-keymap
     "g?" 'notmuch-help
     "q" 'notmuch-bury-or-kill-this-buffer
     "s" 'notmuch-search
@@ -85,14 +85,14 @@
     "Z" 'notmuch-poll-and-refresh-this-buffer
     "J" 'notmuch-jump-search)
 
-  (evil-define-key 'normal notmuch-hello-mode-map
+  (evil-collection-define-key 'normal 'notmuch 'notmuch-hello-mode-map
     "g?" 'notmuch-hello-versions
     (kbd "TAB") 'widget-forward
     (kbd "RET") 'widget-button-press
     (kbd "S-TAB") 'widget-backward
     (kbd "<C-tab>") 'widget-backward)
 
-  (evil-define-key 'normal notmuch-show-mode-map
+  (evil-collection-define-key 'normal 'notmuch 'notmuch-show-mode-map
     "gd" 'goto-address-at-point
     "A" 'notmuch-show-archive-thread-then-next
     "S" 'notmuch-show-filter-thread
@@ -119,7 +119,7 @@
     (kbd "RET") 'notmuch-show-toggle-message
     "." 'notmuch-show-part-map)
 
-  (evil-define-key 'normal notmuch-tree-mode-map
+  (evil-collection-define-key 'normal 'notmuch 'notmuch-tree-mode-map
     "g?" (notmuch-tree-close-message-pane-and 'notmuch-help)
     "q" 'notmuch-tree-quit
     "s" 'notmuch-tree-to-search
@@ -147,7 +147,7 @@
     "*" 'notmuch-tree-tag-thread
     "e" 'notmuch-tree-resume-message)
 
-  (evil-define-key 'normal notmuch-search-mode-map
+  (evil-collection-define-key 'normal 'notmuch 'notmuch-search-mode-map
     "C" 'compose-mail-other-frame
     "J" 'notmuch-jump-search
     "S" 'notmuch-search-filter
@@ -167,7 +167,7 @@
     "+" 'notmuch-search-add-tag
     (kbd "RET") 'notmuch-search-show-thread)
 
-  (evil-define-key 'normal notmuch-search-stash-map
+  (evil-collection-define-key 'normal 'notmuch 'notmuch-search-stash-map
     "i" 'notmuch-search-stash-thread-id
     "q" 'notmuch-stash-query
     "g?" 'notmuch-subkeymap-help))

--- a/evil-collection-notmuch.el
+++ b/evil-collection-notmuch.el
@@ -74,7 +74,7 @@
   (evil-set-initial-state 'notmuch-search-mode 'normal)
   (evil-set-initial-state 'notmuch-hello-mode 'normal)
 
-  (evil-collection-define-key 'normal 'notmuch 'notmuch-common-keymap
+  (evil-collection-define-key 'normal 'notmuch-common-keymap
     "g?" 'notmuch-help
     "q" 'notmuch-bury-or-kill-this-buffer
     "s" 'notmuch-search
@@ -85,14 +85,14 @@
     "Z" 'notmuch-poll-and-refresh-this-buffer
     "J" 'notmuch-jump-search)
 
-  (evil-collection-define-key 'normal 'notmuch 'notmuch-hello-mode-map
+  (evil-collection-define-key 'normal 'notmuch-hello-mode-map
     "g?" 'notmuch-hello-versions
     (kbd "TAB") 'widget-forward
     (kbd "RET") 'widget-button-press
     (kbd "S-TAB") 'widget-backward
     (kbd "<C-tab>") 'widget-backward)
 
-  (evil-collection-define-key 'normal 'notmuch 'notmuch-show-mode-map
+  (evil-collection-define-key 'normal 'notmuch-show-mode-map
     "gd" 'goto-address-at-point
     "A" 'notmuch-show-archive-thread-then-next
     "S" 'notmuch-show-filter-thread
@@ -119,7 +119,7 @@
     (kbd "RET") 'notmuch-show-toggle-message
     "." 'notmuch-show-part-map)
 
-  (evil-collection-define-key 'normal 'notmuch 'notmuch-tree-mode-map
+  (evil-collection-define-key 'normal 'notmuch-tree-mode-map
     "g?" (notmuch-tree-close-message-pane-and 'notmuch-help)
     "q" 'notmuch-tree-quit
     "s" 'notmuch-tree-to-search
@@ -147,7 +147,7 @@
     "*" 'notmuch-tree-tag-thread
     "e" 'notmuch-tree-resume-message)
 
-  (evil-collection-define-key 'normal 'notmuch 'notmuch-search-mode-map
+  (evil-collection-define-key 'normal 'notmuch-search-mode-map
     "C" 'compose-mail-other-frame
     "J" 'notmuch-jump-search
     "S" 'notmuch-search-filter
@@ -167,7 +167,7 @@
     "+" 'notmuch-search-add-tag
     (kbd "RET") 'notmuch-search-show-thread)
 
-  (evil-collection-define-key 'normal 'notmuch 'notmuch-search-stash-map
+  (evil-collection-define-key 'normal 'notmuch-search-stash-map
     "i" 'notmuch-search-stash-thread-id
     "q" 'notmuch-stash-query
     "g?" 'notmuch-subkeymap-help))

--- a/evil-collection-nov.el
+++ b/evil-collection-nov.el
@@ -36,7 +36,7 @@
 
 (defun evil-collection-nov-setup ()
   "Set up `evil' bindings for `nov'."
-  (evil-define-key 'normal nov-mode-map
+  (evil-collection-define-key 'normal 'nov 'nov-mode-map
     "gr" 'nov-render-document
     "s" 'nov-view-source
     "S" 'nov-view-content-source

--- a/evil-collection-nov.el
+++ b/evil-collection-nov.el
@@ -36,7 +36,7 @@
 
 (defun evil-collection-nov-setup ()
   "Set up `evil' bindings for `nov'."
-  (evil-collection-define-key 'normal 'nov 'nov-mode-map
+  (evil-collection-define-key 'normal 'nov-mode-map
     "gr" 'nov-render-document
     "s" 'nov-view-source
     "S" 'nov-view-content-source

--- a/evil-collection-occur.el
+++ b/evil-collection-occur.el
@@ -39,7 +39,7 @@
   "Set up `evil' bindings for `occur'."
   (evil-set-initial-state 'occur-mode 'normal)
 
-  (evil-collection-define-key 'normal 'replace 'occur-mode-map
+  (evil-collection-define-key 'normal 'occur-mode-map
     ;; Like `wdired-mode'.
     (kbd "C-x C-q") 'occur-edit-mode
 
@@ -60,7 +60,7 @@
     "c" 'clone-buffer
     (kbd "C-c C-f") 'next-error-follow-minor-mode)
 
-  (evil-collection-define-key 'normal 'replace 'occur-edit-mode-map
+  (evil-collection-define-key 'normal 'occur-edit-mode-map
     ;; Like `wdired-mode'.
     (kbd "C-x C-q") 'occur-cease-edit
 

--- a/evil-collection-occur.el
+++ b/evil-collection-occur.el
@@ -39,7 +39,7 @@
   "Set up `evil' bindings for `occur'."
   (evil-set-initial-state 'occur-mode 'normal)
 
-  (evil-define-key 'normal occur-mode-map
+  (evil-collection-define-key 'normal 'replace 'occur-mode-map
     ;; Like `wdired-mode'.
     (kbd "C-x C-q") 'occur-edit-mode
 
@@ -60,7 +60,7 @@
     "c" 'clone-buffer
     (kbd "C-c C-f") 'next-error-follow-minor-mode)
 
-  (evil-define-key 'normal occur-edit-mode-map
+  (evil-collection-define-key 'normal 'replace 'occur-edit-mode-map
     ;; Like `wdired-mode'.
     (kbd "C-x C-q") 'occur-cease-edit
 

--- a/evil-collection-outline.el
+++ b/evil-collection-outline.el
@@ -46,10 +46,10 @@ mode."
   "Set up `evil' bindings for `outline'."
   (evil-set-initial-state 'outline-mode 'normal)
   (when evil-collection-outline-bind-tab-p
-    (evil-define-key 'normal outline-mode-map
+    (evil-collection-define-key 'normal 'outline 'outline-mode-map
       (kbd "<backtab>") 'outline-show-all ; Also "z r" by default
       (kbd "<tab>") 'outline-toggle-children)) ; Also "z a" by default
-  (evil-define-key 'normal outline-mode-map
+  (evil-collection-define-key 'normal 'outline 'outline-mode-map
     ;; folding
     ;; Evil default keys:
     ;; zO: Show recursively for current branch only.

--- a/evil-collection-outline.el
+++ b/evil-collection-outline.el
@@ -46,10 +46,10 @@ mode."
   "Set up `evil' bindings for `outline'."
   (evil-set-initial-state 'outline-mode 'normal)
   (when evil-collection-outline-bind-tab-p
-    (evil-collection-define-key 'normal 'outline 'outline-mode-map
+    (evil-collection-define-key 'normal 'outline-mode-map
       (kbd "<backtab>") 'outline-show-all ; Also "z r" by default
       (kbd "<tab>") 'outline-toggle-children)) ; Also "z a" by default
-  (evil-collection-define-key 'normal 'outline 'outline-mode-map
+  (evil-collection-define-key 'normal 'outline-mode-map
     ;; folding
     ;; Evil default keys:
     ;; zO: Show recursively for current branch only.

--- a/evil-collection-p4.el
+++ b/evil-collection-p4.el
@@ -37,7 +37,7 @@
   "Set up `evil' bindings for `p4'."
   (evil-set-initial-state 'p4-basic-mode 'normal)
 
-  (evil-define-key 'normal p4-basic-mode-map
+  (evil-collection-define-key 'normal 'p4 p4-basic-mode-map
     [mouse-1] 'p4-buffer-mouse-clicked
     "k" 'p4-scroll-down-1-line
     "j" 'p4-scroll-up-1-line

--- a/evil-collection-p4.el
+++ b/evil-collection-p4.el
@@ -37,7 +37,7 @@
   "Set up `evil' bindings for `p4'."
   (evil-set-initial-state 'p4-basic-mode 'normal)
 
-  (evil-collection-define-key 'normal 'p4 p4-basic-mode-map
+  (evil-collection-define-key 'normal 'p4-basic-mode-map
     [mouse-1] 'p4-buffer-mouse-clicked
     "k" 'p4-scroll-down-1-line
     "j" 'p4-scroll-up-1-line

--- a/evil-collection-package-menu.el
+++ b/evil-collection-package-menu.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `package-menu'."
   (evil-set-initial-state 'package-menu-mode 'normal)
 
-  (evil-define-key 'normal package-menu-mode-map
+  (evil-collection-define-key 'normal 'package 'package-menu-mode-map
     "i" 'package-menu-mark-install
     "U" 'package-menu-mark-upgrades
     "d" 'package-menu-mark-delete

--- a/evil-collection-package-menu.el
+++ b/evil-collection-package-menu.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `package-menu'."
   (evil-set-initial-state 'package-menu-mode 'normal)
 
-  (evil-collection-define-key 'normal 'package 'package-menu-mode-map
+  (evil-collection-define-key 'normal 'package-menu-mode-map
     "i" 'package-menu-mark-install
     "U" 'package-menu-mark-upgrades
     "d" 'package-menu-mark-delete

--- a/evil-collection-pass.el
+++ b/evil-collection-pass.el
@@ -36,7 +36,7 @@
 
 (defun evil-collection-pass-setup ()
   "Set up `evil' bindings for `pass-mode'."
-  (evil-define-key 'normal pass-mode-map
+  (evil-collection-define-key 'normal 'pass 'pass-mode-map
     "gj" 'pass-next-entry
     "gk" 'pass-prev-entry
     (kbd "C-j") 'pass-next-entry

--- a/evil-collection-pass.el
+++ b/evil-collection-pass.el
@@ -36,7 +36,7 @@
 
 (defun evil-collection-pass-setup ()
   "Set up `evil' bindings for `pass-mode'."
-  (evil-collection-define-key 'normal 'pass 'pass-mode-map
+  (evil-collection-define-key 'normal 'pass-mode-map
     "gj" 'pass-next-entry
     "gk" 'pass-prev-entry
     (kbd "C-j") 'pass-next-entry

--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -86,9 +86,9 @@
 
 (defun evil-collection-pdf-setup ()
   "Set up `evil' bindings for `pdf-view'."
-  (evil-collection-util-inhibit-insert-state pdf-view pdf-view-mode-map)
+  (evil-collection-util-inhibit-insert-state pdf-view-mode-map)
   (evil-set-initial-state 'pdf-view-mode 'normal)
-  (evil-collection-define-key 'normal 'pdf-view 'pdf-view-mode-map
+  (evil-collection-define-key 'normal 'pdf-view-mode-map
     ;; motion
     (kbd "<return>") 'image-next-line
     "j" 'evil-collection-pdf-view-next-line-or-next-page
@@ -177,9 +177,9 @@
     "ZQ" 'kill-this-buffer
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state pdf-outline pdf-outline-buffer-mode-map)
+  (evil-collection-util-inhibit-insert-state pdf-outline-buffer-mode-map)
   (evil-set-initial-state 'pdf-outline-buffer-mode 'normal)
-  (evil-collection-define-key 'normal 'pdf-outline 'pdf-outline-buffer-mode-map
+  (evil-collection-define-key 'normal 'pdf-outline-buffer-mode-map
     ;; open
     (kbd "<return>") 'pdf-outline-follow-link-and-quit
     (kbd "S-<return>") 'pdf-outline-follow-link
@@ -200,9 +200,9 @@
     "ZQ" 'quit-window
     "ZZ" 'pdf-outline-quit-and-kill)
 
-  (evil-collection-util-inhibit-insert-state pdf-occur pdf-occur-buffer-mode-map)
+  (evil-collection-util-inhibit-insert-state pdf-occur-buffer-mode-map)
   (evil-set-initial-state 'pdf-occur-buffer-mode 'normal)
-  (evil-collection-define-key 'normal 'pdf-occur 'pdf-occur-buffer-mode-map
+  (evil-collection-define-key 'normal 'pdf-occur-buffer-mode-map
     ;; open
     (kbd "<return>") 'pdf-occur-goto-occurrence
     (kbd "S-<return>") 'pdf-occur-view-occurrence

--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -86,9 +86,9 @@
 
 (defun evil-collection-pdf-setup ()
   "Set up `evil' bindings for `pdf-view'."
-  (evil-collection-util-inhibit-insert-state pdf-view-mode-map)
+  (evil-collection-util-inhibit-insert-state pdf-view pdf-view-mode-map)
   (evil-set-initial-state 'pdf-view-mode 'normal)
-  (evil-define-key 'normal pdf-view-mode-map
+  (evil-collection-define-key 'normal 'pdf-view 'pdf-view-mode-map
     ;; motion
     (kbd "<return>") 'image-next-line
     "j" 'evil-collection-pdf-view-next-line-or-next-page
@@ -177,9 +177,9 @@
     "ZQ" 'kill-this-buffer
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state pdf-outline-buffer-mode-map)
+  (evil-collection-util-inhibit-insert-state pdf-outline pdf-outline-buffer-mode-map)
   (evil-set-initial-state 'pdf-outline-buffer-mode 'normal)
-  (evil-define-key 'normal pdf-outline-buffer-mode-map
+  (evil-collection-define-key 'normal 'pdf-outline 'pdf-outline-buffer-mode-map
     ;; open
     (kbd "<return>") 'pdf-outline-follow-link-and-quit
     (kbd "S-<return>") 'pdf-outline-follow-link
@@ -200,9 +200,9 @@
     "ZQ" 'quit-window
     "ZZ" 'pdf-outline-quit-and-kill)
 
-  (evil-collection-util-inhibit-insert-state pdf-occur-buffer-mode-map)
+  (evil-collection-util-inhibit-insert-state pdf-occur pdf-occur-buffer-mode-map)
   (evil-set-initial-state 'pdf-occur-buffer-mode 'normal)
-  (evil-define-key 'normal pdf-occur-buffer-mode-map
+  (evil-collection-define-key 'normal 'pdf-occur 'pdf-occur-buffer-mode-map
     ;; open
     (kbd "<return>") 'pdf-occur-goto-occurrence
     (kbd "S-<return>") 'pdf-occur-view-occurrence

--- a/evil-collection-popup.el
+++ b/evil-collection-popup.el
@@ -35,8 +35,9 @@
 (defun evil-collection-popup-setup ()
   "Set up `evil' bindings for `popup'."
   (defvar popup-menu-keymap)
-  (define-key popup-menu-keymap (kbd "C-j") 'popup-next)
-  (define-key popup-menu-keymap (kbd "C-k") 'popup-previous))
+  (evil-collection-define-key nil 'popup-menu-keymap
+    (kbd "C-j") 'popup-next
+    (kbd "C-k") 'popup-previous))
 
 (provide 'evil-collection-popup)
 ;;; evil-collection-popup.el ends here

--- a/evil-collection-proced.el
+++ b/evil-collection-proced.el
@@ -34,9 +34,9 @@
 
 (defun evil-collection-proced-setup ()
   "Set up `evil' bindings for `proced'."
-  (evil-collection-util-inhibit-insert-state proced proced-mode-map)
+  (evil-collection-util-inhibit-insert-state proced-mode-map)
   (evil-set-initial-state 'proced-mode 'normal)
-  (evil-collection-define-key 'normal 'proced 'proced-mode-map
+  (evil-collection-define-key 'normal 'proced-mode-map
     (kbd "<return>") 'proced-refine
 
     ;; mark

--- a/evil-collection-proced.el
+++ b/evil-collection-proced.el
@@ -34,9 +34,9 @@
 
 (defun evil-collection-proced-setup ()
   "Set up `evil' bindings for `proced'."
-  (evil-collection-util-inhibit-insert-state proced-mode-map)
+  (evil-collection-util-inhibit-insert-state proced proced-mode-map)
   (evil-set-initial-state 'proced-mode 'normal)
-  (evil-define-key 'normal proced-mode-map
+  (evil-collection-define-key 'normal 'proced 'proced-mode-map
     (kbd "<return>") 'proced-refine
 
     ;; mark

--- a/evil-collection-prodigy.el
+++ b/evil-collection-prodigy.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-prodigy-setup ()
   "Set up `evil' bindings for `prodigy'."
-  (evil-collection-define-key 'normal 'prodigy 'prodigy-mode-map
+  (evil-collection-define-key 'normal 'prodigy-mode-map
     ;; quit
     "q" 'quit-window
 
@@ -72,7 +72,7 @@
     (kbd "C-k") 'prodigy-prev-with-status
     (kbd "Y") 'prodigy-copy-cmd)
 
-  (evil-collection-define-key 'normal 'prodigy 'prodigy-view-mode-map
+  (evil-collection-define-key 'normal 'prodigy-view-mode-map
     "x" 'prodigy-view-clear-buffer))
 
 (provide 'evil-collection-prodigy)

--- a/evil-collection-prodigy.el
+++ b/evil-collection-prodigy.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-prodigy-setup ()
   "Set up `evil' bindings for `prodigy'."
-  (evil-define-key 'normal prodigy-mode-map
+  (evil-collection-define-key 'normal 'prodigy 'prodigy-mode-map
     ;; quit
     "q" 'quit-window
 
@@ -72,7 +72,7 @@
     (kbd "C-k") 'prodigy-prev-with-status
     (kbd "Y") 'prodigy-copy-cmd)
 
-  (evil-define-key 'normal prodigy-view-mode-map
+  (evil-collection-define-key 'normal 'prodigy 'prodigy-view-mode-map
     "x" 'prodigy-view-clear-buffer))
 
 (provide 'evil-collection-prodigy)

--- a/evil-collection-profiler.el
+++ b/evil-collection-profiler.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `profiler'."
   (evil-set-initial-state 'profiler-report-mode 'normal)
 
-  (evil-collection-define-key 'normal 'profiler 'profiler-report-mode-map
+  (evil-collection-define-key 'normal 'profiler-report-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-profiler.el
+++ b/evil-collection-profiler.el
@@ -36,7 +36,7 @@
   "Set up `evil' bindings for `profiler'."
   (evil-set-initial-state 'profiler-report-mode 'normal)
 
-  (evil-define-key 'normal profiler-report-mode-map
+  (evil-collection-define-key 'normal 'profiler 'profiler-report-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command

--- a/evil-collection-python.el
+++ b/evil-collection-python.el
@@ -40,7 +40,7 @@
   "Set up `evil' bindings for `python'."
   (add-hook 'python-mode-hook #'evil-collection-python-set-evil-shift-width)
 
-  (evil-collection-define-key 'normal 'python 'python-mode-map
+  (evil-collection-define-key 'normal 'python-mode-map
     "gz" 'python-shell-switch-to-shell))
 
 (provide 'evil-collection-python)

--- a/evil-collection-python.el
+++ b/evil-collection-python.el
@@ -40,7 +40,7 @@
   "Set up `evil' bindings for `python'."
   (add-hook 'python-mode-hook #'evil-collection-python-set-evil-shift-width)
 
-  (evil-define-key 'normal python-mode-map
+  (evil-collection-define-key 'normal 'python 'python-mode-map
     "gz" 'python-shell-switch-to-shell))
 
 (provide 'evil-collection-python)

--- a/evil-collection-quickrun.el
+++ b/evil-collection-quickrun.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-quickrun-setup ()
   "Set up `evil' bindings for `quickrun'.."
-  (evil-collection-define-key 'normal 'quickrun 'quickrun--mode-map
+  (evil-collection-define-key 'normal 'quickrun--mode-map
     "q" 'quit-window))
 
 (provide 'evil-collection-quickrun)

--- a/evil-collection-quickrun.el
+++ b/evil-collection-quickrun.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-quickrun-setup ()
   "Set up `evil' bindings for `quickrun'.."
-  (evil-define-key 'normal quickrun--mode-map
+  (evil-collection-define-key 'normal 'quickrun 'quickrun--mode-map
     "q" 'quit-window))
 
 (provide 'evil-collection-quickrun)

--- a/evil-collection-racer.el
+++ b/evil-collection-racer.el
@@ -35,12 +35,12 @@
 
 (defun evil-collection-racer-setup ()
   "Set up `evil' bindings for `racer'."
-  (evil-collection-define-key 'normal 'racer 'racer-mode-map
+  (evil-collection-define-key 'normal 'racer-mode-map
     "gd" 'racer-find-definition
     (kbd "C-t") 'pop-tag-mark
     "K" 'racer-describe)
 
-  (evil-collection-define-key 'normal 'racer 'racer-help-mode-map
+  (evil-collection-define-key 'normal 'racer-help-mode-map
     "q" 'quit-window))
 
 (provide 'evil-collection-racer)

--- a/evil-collection-racer.el
+++ b/evil-collection-racer.el
@@ -35,12 +35,12 @@
 
 (defun evil-collection-racer-setup ()
   "Set up `evil' bindings for `racer'."
-  (evil-define-key 'normal racer-mode-map
+  (evil-collection-define-key 'normal 'racer 'racer-mode-map
     "gd" 'racer-find-definition
     (kbd "C-t") 'pop-tag-mark
     "K" 'racer-describe)
 
-  (evil-define-key 'normal racer-help-mode-map
+  (evil-collection-define-key 'normal 'racer 'racer-help-mode-map
     "q" 'quit-window))
 
 (provide 'evil-collection-racer)

--- a/evil-collection-realgud.el
+++ b/evil-collection-realgud.el
@@ -35,7 +35,7 @@
 (defun evil-collection-realgud-setup ()
   "Set up `evil' bindings for `realgud'."
   ;; This one is to represent `realgud-populate-src-buffer-map-plain'.
-  (evil-collection-define-key 'normal 'realgud 'realgud:shortkey-mode-map
+  (evil-collection-define-key 'normal 'realgud:shortkey-mode-map
     "b" 'realgud:cmd-break
     "u" 'realgud:cmd-delete
     "X" 'realgud:cmd-clear
@@ -63,7 +63,7 @@
     ;; (define-key map [M-S-up]    'realgud-track-hist-oldest)
     )
 
-  (evil-collection-define-key 'normal 'realgud 'realgud:shortkey-mode-map
+  (evil-collection-define-key 'normal 'realgud:shortkey-mode-map
     (kbd "C-x C-q") 'realgud-short-key-mode
     "1" 'realgud-goto-arrow1
     "2" 'realgud-goto-arrow2

--- a/evil-collection-realgud.el
+++ b/evil-collection-realgud.el
@@ -35,7 +35,7 @@
 (defun evil-collection-realgud-setup ()
   "Set up `evil' bindings for `realgud'."
   ;; This one is to represent `realgud-populate-src-buffer-map-plain'.
-  (evil-define-key 'normal realgud:shortkey-mode-map
+  (evil-collection-define-key 'normal 'realgud 'realgud:shortkey-mode-map
     "b" 'realgud:cmd-break
     "u" 'realgud:cmd-delete
     "X" 'realgud:cmd-clear
@@ -63,7 +63,7 @@
     ;; (define-key map [M-S-up]    'realgud-track-hist-oldest)
     )
 
-  (evil-define-key 'normal realgud:shortkey-mode-map
+  (evil-collection-define-key 'normal 'realgud 'realgud:shortkey-mode-map
     (kbd "C-x C-q") 'realgud-short-key-mode
     "1" 'realgud-goto-arrow1
     "2" 'realgud-goto-arrow2

--- a/evil-collection-realgud.el
+++ b/evil-collection-realgud.el
@@ -52,15 +52,15 @@
     "i" 'realgud:cmd-step
     "!" 'realgud:cmd-shell
 
-    ;; (define-key map [M-down]    'realgud-track-hist-newer)
-    ;; (define-key map [M-kp-2]    'realgud-track-hist-newer)
-    ;; (define-key map [M-up]      'realgud-track-hist-older)
-    ;; (define-key map [M-kp-8]    'realgud-track-hist-older)
-    ;; (define-key map [M-kp-up]   'realgud-track-hist-older)
-    ;; (define-key map [M-kp-down] 'realgud-track-hist-newer)
-    ;; (define-key map [M-print]   'realgud-track-hist-older)
-    ;; (define-key map [M-S-down]  'realgud-track-hist-newest)
-    ;; (define-key map [M-S-up]    'realgud-track-hist-oldest)
+    ;; (evil-collection-define-key nil map [M-down]    'realgud-track-hist-newer)
+    ;; (evil-collection-define-key nil map [M-kp-2]    'realgud-track-hist-newer)
+    ;; (evil-collection-define-key nil map [M-up]      'realgud-track-hist-older)
+    ;; (evil-collection-define-key nil map [M-kp-8]    'realgud-track-hist-older)
+    ;; (evil-collection-define-key nil map [M-kp-up]   'realgud-track-hist-older)
+    ;; (evil-collection-define-key nil map [M-kp-down] 'realgud-track-hist-newer)
+    ;; (evil-collection-define-key nil map [M-print]   'realgud-track-hist-older)
+    ;; (evil-collection-define-key nil map [M-S-down]  'realgud-track-hist-newest)
+    ;; (evil-collection-define-key nil map [M-S-up]    'realgud-track-hist-oldest)
     )
 
   (evil-collection-define-key 'normal 'realgud:shortkey-mode-map

--- a/evil-collection-reftex.el
+++ b/evil-collection-reftex.el
@@ -76,7 +76,7 @@
   (evil-set-initial-state 'reftex-select-label-mode 'normal)
   (evil-set-initial-state 'reftex-select-bib-mode 'normal)
 
-  (evil-define-key 'normal reftex-select-shared-map
+  (evil-collection-define-key 'normal 'reftex 'reftex-select-shared-map
     "j" 'reftex-select-next
     "k" 'reftex-select-previous
     (kbd "]") 'reftex-select-next-heading
@@ -120,7 +120,7 @@
 
   ;; This one is more involved, in reftex-toc.el, line 282 it shows the prompt
   ;; string with the keybinds and I don't see any way of changing it to show evil-like binds.
-  (evil-define-key 'normal reftex-toc-mode-map
+  (evil-collection-define-key 'normal 'reftex 'reftex-toc-mode-map
     "j" 'reftex-toc-next
     "k" 'reftex-toc-previous
     (kbd "RET") 'reftex-toc-goto-line-and-hide

--- a/evil-collection-reftex.el
+++ b/evil-collection-reftex.el
@@ -76,7 +76,7 @@
   (evil-set-initial-state 'reftex-select-label-mode 'normal)
   (evil-set-initial-state 'reftex-select-bib-mode 'normal)
 
-  (evil-collection-define-key 'normal 'reftex 'reftex-select-shared-map
+  (evil-collection-define-key 'normal 'reftex-select-shared-map
     "j" 'reftex-select-next
     "k" 'reftex-select-previous
     (kbd "]") 'reftex-select-next-heading
@@ -120,7 +120,7 @@
 
   ;; This one is more involved, in reftex-toc.el, line 282 it shows the prompt
   ;; string with the keybinds and I don't see any way of changing it to show evil-like binds.
-  (evil-collection-define-key 'normal 'reftex 'reftex-toc-mode-map
+  (evil-collection-define-key 'normal 'reftex-toc-mode-map
     "j" 'reftex-toc-next
     "k" 'reftex-toc-previous
     (kbd "RET") 'reftex-toc-goto-line-and-hide

--- a/evil-collection-rjsx-mode.el
+++ b/evil-collection-rjsx-mode.el
@@ -37,9 +37,9 @@
 (defun evil-collection-rjsx-mode-setup ()
   "Set up `evil' bindings for `rjsx-mode'."
   (when evil-want-C-d-scroll
-    (evil-collection-define-key 'insert 'rjsx-mode 'rjsx-mode-map
+    (evil-collection-define-key 'insert 'rjsx-mode-map
       (kbd "C-d") 'rjsx-delete-creates-full-tag)
-    (evil-collection-define-key 'normal 'rjsx-mode 'rjsx-mode-map
+    (evil-collection-define-key 'normal 'rjsx-mode-map
       (kbd "C-d") 'evil-scroll-down)))
 
 (provide 'evil-collection-rjsx-mode)

--- a/evil-collection-rjsx-mode.el
+++ b/evil-collection-rjsx-mode.el
@@ -37,9 +37,9 @@
 (defun evil-collection-rjsx-mode-setup ()
   "Set up `evil' bindings for `rjsx-mode'."
   (when evil-want-C-d-scroll
-    (evil-define-key 'insert rjsx-mode-map
+    (evil-collection-define-key 'insert 'rjsx-mode 'rjsx-mode-map
       (kbd "C-d") 'rjsx-delete-creates-full-tag)
-    (evil-define-key 'normal rjsx-mode-map
+    (evil-collection-define-key 'normal 'rjsx-mode 'rjsx-mode-map
       (kbd "C-d") 'evil-scroll-down)))
 
 (provide 'evil-collection-rjsx-mode)

--- a/evil-collection-robe.el
+++ b/evil-collection-robe.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-robe-setup ()
   "Set up `evil' bindings for `robe'."
-  (evil-define-key 'normal robe-mode-map
+  (evil-collection-define-key 'normal 'robe 'robe-mode-map
     "gd" 'robe-jump
     (kbd "C-t") 'pop-tag-mark
     "K" 'robe-doc

--- a/evil-collection-robe.el
+++ b/evil-collection-robe.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-robe-setup ()
   "Set up `evil' bindings for `robe'."
-  (evil-collection-define-key 'normal 'robe 'robe-mode-map
+  (evil-collection-define-key 'normal 'robe-mode-map
     "gd" 'robe-jump
     (kbd "C-t") 'pop-tag-mark
     "K" 'robe-doc

--- a/evil-collection-rtags.el
+++ b/evil-collection-rtags.el
@@ -47,7 +47,7 @@
   (evil-set-initial-state 'rtags-references-tree-mode 'normal)
   (evil-set-initial-state 'rtags-location-stack-visualize-mode 'normal)
 
-  (evil-collection-define-key 'normal 'rtags 'rtags-mode-map
+  (evil-collection-define-key 'normal 'rtags-mode-map
     ;; open
     (kbd "<return>") 'rtags-select
     (kbd "S-<return>") 'rtags-select-other-window
@@ -62,7 +62,7 @@
     "x" 'rtags-select-and-remove-rtags-buffer
     "q" 'rtags-call-bury-or-delete)
 
-  (evil-collection-define-key 'normal 'rtags 'rtags-dependency-tree-mode-map
+  (evil-collection-define-key 'normal 'rtags-dependency-tree-mode-map
     (kbd "<tab>") 'rtags-dependency-tree-toggle-current-expanded
     "E" 'rtags-dependency-tree-expand-all
     "c" 'rtags-dependency-tree-collapse-all
@@ -92,7 +92,7 @@
     "x" 'rtags-select-and-remove-rtags-buffer
     "q" 'rtags-call-bury-or-delete)
 
-  (evil-collection-define-key 'normal 'rtags 'rtags-references-tree-mode-map
+  (evil-collection-define-key 'normal 'rtags-references-tree-mode-map
     (kbd "<tab>") 'rtags-references-tree-toggle-current-expanded
 
     "E" 'rtags-references-tree-expand-all
@@ -122,7 +122,7 @@
     "x" 'rtags-select-and-remove-rtags-buffer
     "q" 'rtags-call-bury-or-delete)
 
-  (evil-collection-define-key 'normal 'rtags 'rtags-location-stack-visualize-mode-map
+  (evil-collection-define-key 'normal 'rtags-location-stack-visualize-mode-map
     ;; open
     (kbd "<return>") 'rtags-select
     (kbd "S-<return>") 'rtags-select-other-window

--- a/evil-collection-rtags.el
+++ b/evil-collection-rtags.el
@@ -47,7 +47,7 @@
   (evil-set-initial-state 'rtags-references-tree-mode 'normal)
   (evil-set-initial-state 'rtags-location-stack-visualize-mode 'normal)
 
-  (evil-define-key 'normal rtags-mode-map
+  (evil-collection-define-key 'normal 'rtags 'rtags-mode-map
     ;; open
     (kbd "<return>") 'rtags-select
     (kbd "S-<return>") 'rtags-select-other-window
@@ -62,7 +62,7 @@
     "x" 'rtags-select-and-remove-rtags-buffer
     "q" 'rtags-call-bury-or-delete)
 
-  (evil-define-key 'normal rtags-dependency-tree-mode-map
+  (evil-collection-define-key 'normal 'rtags 'rtags-dependency-tree-mode-map
     (kbd "<tab>") 'rtags-dependency-tree-toggle-current-expanded
     "E" 'rtags-dependency-tree-expand-all
     "c" 'rtags-dependency-tree-collapse-all
@@ -92,7 +92,7 @@
     "x" 'rtags-select-and-remove-rtags-buffer
     "q" 'rtags-call-bury-or-delete)
 
-  (evil-define-key 'normal rtags-references-tree-mode-map
+  (evil-collection-define-key 'normal 'rtags 'rtags-references-tree-mode-map
     (kbd "<tab>") 'rtags-references-tree-toggle-current-expanded
 
     "E" 'rtags-references-tree-expand-all
@@ -122,7 +122,7 @@
     "x" 'rtags-select-and-remove-rtags-buffer
     "q" 'rtags-call-bury-or-delete)
 
-  (evil-define-key 'normal rtags-location-stack-visualize-mode-map
+  (evil-collection-define-key 'normal 'rtags 'rtags-location-stack-visualize-mode-map
     ;; open
     (kbd "<return>") 'rtags-select
     (kbd "S-<return>") 'rtags-select-other-window

--- a/evil-collection-simple.el
+++ b/evil-collection-simple.el
@@ -36,7 +36,7 @@
 
 (defun evil-collection-simple-setup ()
   "Set up `evil' bindings for `simple'."
-  (evil-collection-define-key '(normal visual) 'simple 'special-mode-map
+  (evil-collection-define-key '(normal visual) 'special-mode-map
     "q" 'quit-window
     " " 'scroll-up-command
     "g?" 'describe-mode

--- a/evil-collection-simple.el
+++ b/evil-collection-simple.el
@@ -36,7 +36,7 @@
 
 (defun evil-collection-simple-setup ()
   "Set up `evil' bindings for `simple'."
-  (evil-define-key '(normal visual) special-mode-map
+  (evil-collection-define-key '(normal visual) 'simple 'special-mode-map
     "q" 'quit-window
     " " 'scroll-up-command
     "g?" 'describe-mode

--- a/evil-collection-slime.el
+++ b/evil-collection-slime.el
@@ -67,11 +67,11 @@
   (evil-set-initial-state 'slime-popup-buffer-mode 'normal)
   (evil-set-initial-state 'slime-xref-mode 'normal)
 
-  (evil-define-key 'normal slime-parent-map
+  (evil-collection-define-key 'normal 'slime 'slime-parent-map
     "gd" 'slime-edit-definition
     (kbd "C-t") 'slime-pop-find-definition-stack)
 
-  (evil-define-key 'normal sldb-mode-map
+  (evil-collection-define-key 'normal 'slime 'sldb-mode-map
     (kbd "RET") 'sldb-default-action
     (kbd "C-m") 'sldb-default-action
     [return] 'sldb-default-action
@@ -121,7 +121,7 @@
     "8" 'sldb-invoke-restart-8
     "9" 'sldb-invoke-restart-9)
 
-  (evil-define-key 'normal slime-inspector-mode-map
+  (evil-collection-define-key 'normal 'slime 'slime-inspector-mode-map
     [return] 'slime-inspector-operate-on-point
     (kbd "C-m") 'slime-inspector-operate-on-point
     [mouse-1] 'slime-inspector-operate-on-click
@@ -147,13 +147,13 @@
     "gR" 'slime-inspector-fetch-all
     "q" 'slime-inspector-quit)
 
-  (evil-define-key 'normal slime-mode-map
+  (evil-collection-define-key 'normal 'slime 'slime-mode-map
     (kbd "K") 'slime-describe-symbol
     (kbd "C-t") 'slime-pop-find-definition-stack
     ;; goto
     "gd" 'slime-edit-definition)
 
-  (evil-define-key 'normal slime-popup-buffer-mode-map
+  (evil-collection-define-key 'normal 'slime 'slime-popup-buffer-mode-map
     ;; quit
     "q" 'quit-window
 
@@ -162,7 +162,7 @@
     ;; goto
     "gd" 'slime-edit-definition)
 
-  (evil-define-key 'normal slime-xref-mode-map
+  (evil-collection-define-key 'normal 'slime 'slime-xref-mode-map
     (kbd "RET") 'slime-goto-xref
     (kbd "S-<return>") 'slime-goto-xref
     "go" 'slime-show-xref

--- a/evil-collection-slime.el
+++ b/evil-collection-slime.el
@@ -67,11 +67,11 @@
   (evil-set-initial-state 'slime-popup-buffer-mode 'normal)
   (evil-set-initial-state 'slime-xref-mode 'normal)
 
-  (evil-collection-define-key 'normal 'slime 'slime-parent-map
+  (evil-collection-define-key 'normal 'slime-parent-map
     "gd" 'slime-edit-definition
     (kbd "C-t") 'slime-pop-find-definition-stack)
 
-  (evil-collection-define-key 'normal 'slime 'sldb-mode-map
+  (evil-collection-define-key 'normal 'sldb-mode-map
     (kbd "RET") 'sldb-default-action
     (kbd "C-m") 'sldb-default-action
     [return] 'sldb-default-action
@@ -121,7 +121,7 @@
     "8" 'sldb-invoke-restart-8
     "9" 'sldb-invoke-restart-9)
 
-  (evil-collection-define-key 'normal 'slime 'slime-inspector-mode-map
+  (evil-collection-define-key 'normal 'slime-inspector-mode-map
     [return] 'slime-inspector-operate-on-point
     (kbd "C-m") 'slime-inspector-operate-on-point
     [mouse-1] 'slime-inspector-operate-on-click
@@ -147,13 +147,13 @@
     "gR" 'slime-inspector-fetch-all
     "q" 'slime-inspector-quit)
 
-  (evil-collection-define-key 'normal 'slime 'slime-mode-map
+  (evil-collection-define-key 'normal 'slime-mode-map
     (kbd "K") 'slime-describe-symbol
     (kbd "C-t") 'slime-pop-find-definition-stack
     ;; goto
     "gd" 'slime-edit-definition)
 
-  (evil-collection-define-key 'normal 'slime 'slime-popup-buffer-mode-map
+  (evil-collection-define-key 'normal 'slime-popup-buffer-mode-map
     ;; quit
     "q" 'quit-window
 
@@ -162,7 +162,7 @@
     ;; goto
     "gd" 'slime-edit-definition)
 
-  (evil-collection-define-key 'normal 'slime 'slime-xref-mode-map
+  (evil-collection-define-key 'normal 'slime-xref-mode-map
     (kbd "RET") 'slime-goto-xref
     (kbd "S-<return>") 'slime-goto-xref
     "go" 'slime-show-xref

--- a/evil-collection-term.el
+++ b/evil-collection-term.el
@@ -114,7 +114,7 @@ it is not appropriate in some cases like terminals."
 
   ;; Evil has some "C-" bindings in insert state that shadow regular terminal bindings.
   ;; Don't raw-send "C-c" (prefix key) nor "C-h" (help prefix).
-  (evil-define-key 'insert term-raw-map
+  (evil-collection-define-key 'insert 'term 'term-raw-map
     (kbd "C-a") 'term-send-raw
     (kbd "C-b") 'term-send-raw ; Should not be necessary.
     (kbd "C-d") 'term-send-raw
@@ -138,7 +138,7 @@ it is not appropriate in some cases like terminals."
     (kbd "C-c C-d") 'term-send-eof
     (kbd "C-c C-z") 'term-stop-subjob)
 
-  (evil-define-key 'normal term-mode-map
+  (evil-collection-define-key 'normal 'term 'term-mode-map
     (kbd "C-c C-k") 'evil-collection-term-char-mode-insert
     (kbd "<return>") 'term-send-input
 

--- a/evil-collection-term.el
+++ b/evil-collection-term.el
@@ -114,7 +114,7 @@ it is not appropriate in some cases like terminals."
 
   ;; Evil has some "C-" bindings in insert state that shadow regular terminal bindings.
   ;; Don't raw-send "C-c" (prefix key) nor "C-h" (help prefix).
-  (evil-collection-define-key 'insert 'term 'term-raw-map
+  (evil-collection-define-key 'insert 'term-raw-map
     (kbd "C-a") 'term-send-raw
     (kbd "C-b") 'term-send-raw ; Should not be necessary.
     (kbd "C-d") 'term-send-raw
@@ -138,7 +138,7 @@ it is not appropriate in some cases like terminals."
     (kbd "C-c C-d") 'term-send-eof
     (kbd "C-c C-z") 'term-stop-subjob)
 
-  (evil-collection-define-key 'normal 'term 'term-mode-map
+  (evil-collection-define-key 'normal 'term-mode-map
     (kbd "C-c C-k") 'evil-collection-term-char-mode-insert
     (kbd "<return>") 'term-send-input
 

--- a/evil-collection-tide.el
+++ b/evil-collection-tide.el
@@ -36,12 +36,12 @@
 
 (defun evil-collection-tide-setup ()
   "Set up `evil' bindings for `tide'."
-  (evil-define-key 'normal tide-mode-map
+  (evil-collection-define-key 'normal 'tide 'tide-mode-map
     "gd" 'tide-jump-to-definition
     (kbd "C-t") 'tide-jump-back
     "K" 'tide-documentation-at-point)
 
-  (evil-define-key 'normal tide-references-mode-map
+  (evil-collection-define-key 'normal 'tide 'tide-references-mode-map
     "gj" 'tide-find-next-reference
     "gk" 'tide-find-previous-reference
     (kbd "C-j") 'tide-find-next-reference
@@ -51,7 +51,7 @@
     ;; quit
     "q" 'quit-window)
 
-  (evil-define-key 'normal tide-project-errors-mode-map
+  (evil-collection-define-key 'normal 'tide 'tide-project-errors-mode-map
     "gj" 'tide-find-next-error
     "gk" 'tide-find-previous-error
     (kbd "C-j") 'tide-find-next-error

--- a/evil-collection-tide.el
+++ b/evil-collection-tide.el
@@ -36,12 +36,12 @@
 
 (defun evil-collection-tide-setup ()
   "Set up `evil' bindings for `tide'."
-  (evil-collection-define-key 'normal 'tide 'tide-mode-map
+  (evil-collection-define-key 'normal 'tide-mode-map
     "gd" 'tide-jump-to-definition
     (kbd "C-t") 'tide-jump-back
     "K" 'tide-documentation-at-point)
 
-  (evil-collection-define-key 'normal 'tide 'tide-references-mode-map
+  (evil-collection-define-key 'normal 'tide-references-mode-map
     "gj" 'tide-find-next-reference
     "gk" 'tide-find-previous-reference
     (kbd "C-j") 'tide-find-next-reference
@@ -51,7 +51,7 @@
     ;; quit
     "q" 'quit-window)
 
-  (evil-collection-define-key 'normal 'tide 'tide-project-errors-mode-map
+  (evil-collection-define-key 'normal 'tide-project-errors-mode-map
     "gj" 'tide-find-next-error
     "gk" 'tide-find-previous-error
     (kbd "C-j") 'tide-find-next-error

--- a/evil-collection-transmission.el
+++ b/evil-collection-transmission.el
@@ -44,9 +44,9 @@
 (defun evil-collection-transmission-setup ()
   "Set up `evil' bindings for `transmission'."
 
-  (evil-collection-util-inhibit-insert-state transmission transmission-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission-mode-map)
   (evil-set-initial-state 'transmission-mode 'normal)
-  (evil-collection-define-key 'normal 'transmission 'transmission-mode-map
+  (evil-collection-define-key 'normal 'transmission-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
@@ -84,9 +84,9 @@
     "ZQ" 'evil-quit
     "ZZ" 'transmission-quit)
 
-  (evil-collection-util-inhibit-insert-state transmission transmission-files-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission-files-mode-map)
   (evil-set-initial-state 'transmission-files-mode 'normal)
-  (evil-collection-define-key 'normal 'transmission 'transmission-files-mode-map
+  (evil-collection-define-key 'normal 'transmission-files-mode-map
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
     (kbd "<delete>") 'scroll-down-command
@@ -125,9 +125,9 @@
     "ZQ" 'evil-quit
     "ZZ" 'transmission-quit)
 
-  (evil-collection-util-inhibit-insert-state transmission transmission-info-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission-info-mode-map)
   (evil-set-initial-state 'transmission-info-mode 'normal)
-  (evil-collection-define-key 'normal 'transmission 'transmission-info-mode-map
+  (evil-collection-define-key 'normal 'transmission-info-mode-map
     "p" 'transmission-peers
 
     "t" 'transmission-trackers-add
@@ -143,7 +143,7 @@
     "ZQ" 'evil-quit
     "ZZ" 'quit-window)
 
-  (evil-collection-define-key 'operator 'transmission 'transmission-info-mode-map
+  (evil-collection-define-key 'operator 'transmission-info-mode-map
     ;; Like `eww'.
     "u" '(menu-item
           ""
@@ -155,9 +155,9 @@
                       #'transmission-copy-magnet))))
 
 
-  (evil-collection-util-inhibit-insert-state transmission transmission-peers-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission-peers-mode-map)
   (evil-set-initial-state 'transmission-peers-mode 'normal)
-  (evil-collection-define-key 'normal 'transmission 'transmission-peers-mode-map
+  (evil-collection-define-key 'normal 'transmission-peers-mode-map
     ;; sort
     "o" 'tabulated-list-sort
 

--- a/evil-collection-transmission.el
+++ b/evil-collection-transmission.el
@@ -44,9 +44,9 @@
 (defun evil-collection-transmission-setup ()
   "Set up `evil' bindings for `transmission'."
 
-  (evil-collection-util-inhibit-insert-state transmission-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission transmission-mode-map)
   (evil-set-initial-state 'transmission-mode 'normal)
-  (evil-define-key 'normal transmission-mode-map
+  (evil-collection-define-key 'normal 'transmission 'transmission-mode-map
     ;; motion
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
@@ -84,9 +84,9 @@
     "ZQ" 'evil-quit
     "ZZ" 'transmission-quit)
 
-  (evil-collection-util-inhibit-insert-state transmission-files-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission transmission-files-mode-map)
   (evil-set-initial-state 'transmission-files-mode 'normal)
-  (evil-define-key 'normal transmission-files-mode-map
+  (evil-collection-define-key 'normal 'transmission 'transmission-files-mode-map
     (kbd "SPC") 'scroll-up-command
     (kbd "S-SPC") 'scroll-down-command
     (kbd "<delete>") 'scroll-down-command
@@ -125,9 +125,9 @@
     "ZQ" 'evil-quit
     "ZZ" 'transmission-quit)
 
-  (evil-collection-util-inhibit-insert-state transmission-info-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission transmission-info-mode-map)
   (evil-set-initial-state 'transmission-info-mode 'normal)
-  (evil-define-key 'normal transmission-info-mode-map
+  (evil-collection-define-key 'normal 'transmission 'transmission-info-mode-map
     "p" 'transmission-peers
 
     "t" 'transmission-trackers-add
@@ -143,7 +143,7 @@
     "ZQ" 'evil-quit
     "ZZ" 'quit-window)
 
-  (evil-define-key 'operator transmission-info-mode-map
+  (evil-collection-define-key 'operator 'transmission 'transmission-info-mode-map
     ;; Like `eww'.
     "u" '(menu-item
           ""
@@ -155,9 +155,9 @@
                       #'transmission-copy-magnet))))
 
 
-  (evil-collection-util-inhibit-insert-state transmission-peers-mode-map)
+  (evil-collection-util-inhibit-insert-state transmission transmission-peers-mode-map)
   (evil-set-initial-state 'transmission-peers-mode 'normal)
-  (evil-define-key 'normal transmission-peers-mode-map
+  (evil-collection-define-key 'normal 'transmission 'transmission-peers-mode-map
     ;; sort
     "o" 'tabulated-list-sort
 

--- a/evil-collection-util.el
+++ b/evil-collection-util.el
@@ -29,11 +29,11 @@
 ;;; Code:
 (require 'evil)
 
-(defmacro evil-collection-util-inhibit-insert-state (package map)
+(defmacro evil-collection-util-inhibit-insert-state (map)
   "Unmap insertion keys from normal state.
 This is particularly useful for read-only modes."
   `(evil-collection-define-key
-     'normal ',package ',map
+     'normal ',map
      [remap evil-append] #'ignore
      [remap evil-append-line] #'ignore
      [remap evil-insert] #'ignore

--- a/evil-collection-util.el
+++ b/evil-collection-util.el
@@ -29,11 +29,11 @@
 ;;; Code:
 (require 'evil)
 
-(defmacro evil-collection-util-inhibit-insert-state (map)
+(defmacro evil-collection-util-inhibit-insert-state (package map)
   "Unmap insertion keys from normal state.
 This is particularly useful for read-only modes."
-  `(evil-define-key
-     'normal ,map
+  `(evil-collection-define-key
+     'normal ',package ',map
      [remap evil-append] #'ignore
      [remap evil-append-line] #'ignore
      [remap evil-insert] #'ignore

--- a/evil-collection-vc-annotate.el
+++ b/evil-collection-vc-annotate.el
@@ -35,7 +35,7 @@
 (defun evil-collection-vc-annotate-setup ()
   "Set up `evil' bindings for `vc-annotate'."
   (evil-set-initial-state 'vc-annotate-mode 'normal)
-  (evil-collection-define-key 'normal 'vc-annotate 'vc-annotate-mode-map
+  (evil-collection-define-key 'normal 'vc-annotate-mode-map
     "q" 'quit-window
     "a" 'vc-annotate-revision-previous-to-line
     "d" 'vc-annotate-show-diff-revision-at-line

--- a/evil-collection-vc-annotate.el
+++ b/evil-collection-vc-annotate.el
@@ -35,7 +35,7 @@
 (defun evil-collection-vc-annotate-setup ()
   "Set up `evil' bindings for `vc-annotate'."
   (evil-set-initial-state 'vc-annotate-mode 'normal)
-  (evil-define-key 'normal vc-annotate-mode-map
+  (evil-collection-define-key 'normal 'vc-annotate 'vc-annotate-mode-map
     "q" 'quit-window
     "a" 'vc-annotate-revision-previous-to-line
     "d" 'vc-annotate-show-diff-revision-at-line

--- a/evil-collection-view.el
+++ b/evil-collection-view.el
@@ -35,7 +35,7 @@
 (defun evil-collection-view-setup ()
   "Set up `evil' bindings for `view'."
   (evil-set-initial-state 'view-mode 'normal)
-  (evil-collection-define-key 'normal 'view 'view-mode-map
+  (evil-collection-define-key 'normal 'view-mode-map
     "q" 'quit-window
     (kbd "SPC") 'View-scroll-page-forward
     (kbd "S-SPC") 'View-scroll-page-backward

--- a/evil-collection-view.el
+++ b/evil-collection-view.el
@@ -35,7 +35,7 @@
 (defun evil-collection-view-setup ()
   "Set up `evil' bindings for `view'."
   (evil-set-initial-state 'view-mode 'normal)
-  (evil-define-key 'normal view-mode-map
+  (evil-collection-define-key 'normal 'view 'view-mode-map
     "q" 'quit-window
     (kbd "SPC") 'View-scroll-page-forward
     (kbd "S-SPC") 'View-scroll-page-backward

--- a/evil-collection-vlf.el
+++ b/evil-collection-vlf.el
@@ -45,7 +45,7 @@
   "Set up `evil' bindings for `vlf'."
   (evil-set-initial-state 'vlf-mode 'normal)
 
-  (evil-define-key 'normal vlf-mode-map
+  (evil-collection-define-key 'normal 'vlf 'vlf-mode-map
     "gj" 'vlf-next-batch
     "gk" 'vlf-prev-batch
     (kbd "C-j") 'vlf-next-batch

--- a/evil-collection-vlf.el
+++ b/evil-collection-vlf.el
@@ -45,7 +45,7 @@
   "Set up `evil' bindings for `vlf'."
   (evil-set-initial-state 'vlf-mode 'normal)
 
-  (evil-collection-define-key 'normal 'vlf 'vlf-mode-map
+  (evil-collection-define-key 'normal 'vlf-mode-map
     "gj" 'vlf-next-batch
     "gk" 'vlf-prev-batch
     (kbd "C-j") 'vlf-next-batch

--- a/evil-collection-wdired.el
+++ b/evil-collection-wdired.el
@@ -34,10 +34,10 @@
 
 (defun evil-collection-wdired-setup ()
   "Set up `evil' bindings for `wdired'."
-  (evil-collection-define-key nil 'wdired wdired-mode-map
+  (evil-collection-define-key nil 'wdired-mode-map
     [remap evil-write] 'wdired-finish-edit)
 
-  (evil-collection-define-key 'normal 'wdired wdired-mode-map
+  (evil-collection-define-key 'normal 'wdired-mode-map
     "ZQ" 'wdired-abort-changes
     "ZZ" 'wdired-finish-edit
     (kbd "<escape>") 'wdired-exit))

--- a/evil-collection-wdired.el
+++ b/evil-collection-wdired.el
@@ -34,10 +34,10 @@
 
 (defun evil-collection-wdired-setup ()
   "Set up `evil' bindings for `wdired'."
-  (evil-define-key nil wdired-mode-map
+  (evil-collection-define-key nil 'wdired wdired-mode-map
     [remap evil-write] 'wdired-finish-edit)
 
-  (evil-define-key 'normal wdired-mode-map
+  (evil-collection-define-key 'normal 'wdired wdired-mode-map
     "ZQ" 'wdired-abort-changes
     "ZZ" 'wdired-finish-edit
     (kbd "<escape>") 'wdired-exit))

--- a/evil-collection-wgrep.el
+++ b/evil-collection-wgrep.el
@@ -36,10 +36,10 @@
 
 (defun evil-collection-wgrep-setup ()
   "Set up `evil' bindings for `wgrep'."
-  (evil-define-key nil wgrep-mode-map
+  (evil-collection-define-key nil 'wgrep wgrep-mode-map
     [remap evil-write] 'wgrep-finish-edit)
 
-  (evil-define-key 'normal wgrep-mode-map
+  (evil-collection-define-key 'normal 'wgrep wgrep-mode-map
     "ZQ" 'wgrep-abort-changes
     "ZZ" 'wgrep-finish-edit
     (kbd "<escape>") 'wgrep-exit))

--- a/evil-collection-wgrep.el
+++ b/evil-collection-wgrep.el
@@ -36,10 +36,10 @@
 
 (defun evil-collection-wgrep-setup ()
   "Set up `evil' bindings for `wgrep'."
-  (evil-collection-define-key nil 'wgrep wgrep-mode-map
+  (evil-collection-define-key nil 'wgrep-mode-map
     [remap evil-write] 'wgrep-finish-edit)
 
-  (evil-collection-define-key 'normal 'wgrep wgrep-mode-map
+  (evil-collection-define-key 'normal 'wgrep-mode-map
     "ZQ" 'wgrep-abort-changes
     "ZZ" 'wgrep-finish-edit
     (kbd "<escape>") 'wgrep-exit))

--- a/evil-collection-which-key.el
+++ b/evil-collection-which-key.el
@@ -40,11 +40,12 @@
 (defun evil-collection-which-key-setup ()
   "Set up `evil' bindings for `which-key'."
 
-  ;; (define-key which-key-C-h-map "u" 'which-key-undo-key)
-  (define-key which-key-C-h-map "q" 'which-key-abort)
-  (define-key which-key-C-h-map "j" 'which-key-show-next-page-cycle)
-  (define-key which-key-C-h-map "k" 'which-key-show-previous-page-cycle)
-  (define-key which-key-C-h-map "?" 'which-key-show-standard-help))
+  ;; (evil-collection-define-key nil 'which-key-C-h-map "u" 'which-key-undo-key)
+  (evil-collection-define-key nil 'which-key-C-h-map
+    "q" 'which-key-abort
+    "j" 'which-key-show-next-page-cycle
+    "k" 'which-key-show-previous-page-cycle
+    "?" 'which-key-show-standard-help))
 
 (provide 'evil-collection-which-key)
 ;;; evil-collection-which-key.el ends here

--- a/evil-collection-woman.el
+++ b/evil-collection-woman.el
@@ -36,7 +36,7 @@
 (defun evil-collection-woman-setup ()
   "Set up `evil' bindings for `woman'."
   (evil-set-initial-state 'woman-mode 'normal)
-  (evil-collection-define-key 'normal 'woman 'woman-mode-map
+  (evil-collection-define-key 'normal 'woman-mode-map
     (kbd "]") 'WoMan-next-manpage
     (kbd "[") 'WoMan-previous-manpage
 

--- a/evil-collection-woman.el
+++ b/evil-collection-woman.el
@@ -36,7 +36,7 @@
 (defun evil-collection-woman-setup ()
   "Set up `evil' bindings for `woman'."
   (evil-set-initial-state 'woman-mode 'normal)
-  (evil-define-key 'normal woman-mode-map
+  (evil-collection-define-key 'normal 'woman 'woman-mode-map
     (kbd "]") 'WoMan-next-manpage
     (kbd "[") 'WoMan-previous-manpage
 

--- a/evil-collection-xref.el
+++ b/evil-collection-xref.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-xref-setup ()
   "Set up `evil' bindings for `xref'."
-  (evil-define-key 'normal xref--xref-buffer-mode-map
+  (evil-collection-define-key 'normal 'xref 'xref--xref-buffer-mode-map
     "q" 'quit-window
     "gj" 'xref-next-line
     "gk" 'xref-prev-line

--- a/evil-collection-xref.el
+++ b/evil-collection-xref.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-xref-setup ()
   "Set up `evil' bindings for `xref'."
-  (evil-collection-define-key 'normal 'xref 'xref--xref-buffer-mode-map
+  (evil-collection-define-key 'normal 'xref--xref-buffer-mode-map
     "q" 'quit-window
     "gj" 'xref-next-line
     "gk" 'xref-prev-line

--- a/evil-collection-ztree.el
+++ b/evil-collection-ztree.el
@@ -37,9 +37,9 @@
 (defun evil-collection-ztree-setup ()
   "Set up `evil' bindings for `ztree'."
 
-  (evil-collection-util-inhibit-insert-state ztree-mode-map)
+  (evil-collection-util-inhibit-insert-state ztree ztree-mode-map)
   (evil-set-initial-state 'ztree-mode 'normal)
-  (evil-define-key 'normal ztree-mode-map
+  (evil-collection-define-key 'normal 'ztree 'ztree-mode-map
     (kbd "<tab>") 'ztree-jump-side
     (kbd "<return>") 'ztree-perform-action
     (kbd "SPC") 'ztree-perform-soft-action
@@ -54,7 +54,7 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state ztreediff-mode-map)
+  (evil-collection-util-inhibit-insert-state ztree ztreediff-mode-map)
   (evil-set-initial-state 'ztree-mode 'normal)
   (evil-define-minor-mode-key 'normal 'ztreediff-mode
     "C" 'ztree-diff-copy

--- a/evil-collection-ztree.el
+++ b/evil-collection-ztree.el
@@ -37,9 +37,9 @@
 (defun evil-collection-ztree-setup ()
   "Set up `evil' bindings for `ztree'."
 
-  (evil-collection-util-inhibit-insert-state ztree ztree-mode-map)
+  (evil-collection-util-inhibit-insert-state ztree-mode-map)
   (evil-set-initial-state 'ztree-mode 'normal)
-  (evil-collection-define-key 'normal 'ztree 'ztree-mode-map
+  (evil-collection-define-key 'normal 'ztree-mode-map
     (kbd "<tab>") 'ztree-jump-side
     (kbd "<return>") 'ztree-perform-action
     (kbd "SPC") 'ztree-perform-soft-action
@@ -54,7 +54,7 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-util-inhibit-insert-state ztree ztreediff-mode-map)
+  (evil-collection-util-inhibit-insert-state ztreediff-mode-map)
   (evil-set-initial-state 'ztree-mode 'normal)
   (evil-define-minor-mode-key 'normal 'ztreediff-mode
     "C" 'ztree-diff-copy

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -179,7 +179,7 @@ This is a list of strings that are suitable for input to `kbd'."
   :type '(repeat string)
   :group 'evil-collection)
 
-(defvar evil-collection-bindings-record (make-hash-table :test 'eq)
+(defvar evil-collection--bindings-record (make-hash-table :test 'eq)
   "Record of bindings currently made by Evil Collection. This is
 a hash-table with the package symbol as a key. The associated
 values are the package's bindings which are stored as a hash-table with key
@@ -201,11 +201,11 @@ compatibility.")
   "Wrapper for `evil-define-key*' with additional features.
 Filter keys on the basis of `evil-collection-key-whitelist' and
 `evil-collection-key-blacklist'. Store bindings in
-`evil-collection-bindings-record'."
+`evil-collection--bindings-record'."
   (declare (indent defun))
   (let* ((whitelist (mapcar 'kbd evil-collection-key-whitelist))
          (blacklist (mapcar 'kbd evil-collection-key-blacklist))
-         (record (gethash package evil-collection-bindings-record
+         (record (gethash package evil-collection--bindings-record
                           (make-hash-table :test 'equal))))
     (while bindings
       (let ((key (pop bindings))
@@ -219,7 +219,7 @@ Filter keys on the basis of `evil-collection-key-whitelist' and
                (error
                 (message "evil-collection: Bad binding %s"
                          '(evil-define-key* ',state ,map-sym ,key ',def))))))))
-    (puthash package record evil-collection-bindings-record)))
+    (puthash package record evil-collection--bindings-record)))
 
 (defun evil-collection-describe-all-bindings ()
   "Print bindings made by Evil Collection to separate buffer."
@@ -244,7 +244,7 @@ Filter keys on the basis of `evil-collection-key-whitelist' and
               (insert (format "| %s | %S |\n" (key-description key) def))))
           bindings)
          (org-table-align))
-       evil-collection-bindings-record))))
+       evil-collection--bindings-record))))
 
 (defun evil-collection--translate-key (state keymap-symbol
                                              translations

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -220,6 +220,28 @@ Filter keys on the basis of `evil-collection-key-whitelist' and
       (push (cons package record) evil-collection-bindings-record))
     nil))
 
+(defun evil-collection-describe-all-bindings ()
+  "Print bindings made by evil-collection to separate buffer."
+  (interactive)
+  (let ((buf (get-buffer-create "*evil-collection*")))
+    (switch-to-buffer-other-window buf)
+    (with-current-buffer buf
+      (erase-buffer)
+      (org-mode)
+      (dolist (package evil-collection-bindings-record)
+        (insert "\n\n* " (symbol-name (car package)) )
+        (insert "
+| Key | Definition |
+|-----|------------|
+")
+        (dolist (binding (cdr package))
+          ;; Don't print nil definitions
+          (when (cdr binding)
+            ;; FIXME: Handle keys with | in them
+            (insert (format "| %s | %S |\n"
+                            (key-description (car binding)) (cdr binding)))))
+        (org-table-align)))))
+
 (defun evil-collection--translate-key (state keymap-symbol
                                              translations
                                              destructive)

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -240,8 +240,10 @@ Filter keys on the basis of `evil-collection-key-whitelist' and
           (lambda (key def)
             ;; Don't print nil definitions
             (when def
-              ;; FIXME: Handle keys with | in them
-              (insert (format "| %s | %S |\n" (key-description key) def))))
+              (insert (format "| %s | %S |\n"
+                              (replace-regexp-in-string
+                               "|" "¦" (key-description key))
+                              def))))
           bindings)
          (org-table-align))
        evil-collection--bindings-record))))


### PR DESCRIPTION
I implemented a `evil-collection-define-key` function to support whitelists and blacklists. I also added the ability to record and print key bindings made by this package. The print function is a little rudimentary, and this should be tested before it is merged, but it seems to work fine for me so far. 