### PR TITLE
Fix eval-after-load call in ec-ediff-setup

### DIFF
--- a/evil-collection-ediff.el
+++ b/evil-collection-ediff.el
@@ -181,8 +181,7 @@
   (interactive)
   (evil-set-initial-state 'ediff-mode 'normal)
   (add-hook 'ediff-startup-hook 'evil-collection-ediff-startup-hook)
-  (eval-after-load
-      '(evil-collection-ediff-adjust-help)))
+  (evil-collection-ediff-adjust-help))
 
 (defun evil-collection-ediff-revert ()
   "Revert changes made by evil-ediff."


### PR DESCRIPTION
Btw, maybe it would be good to emit a warning if evil-ediff is also installed, since it can cause a conflict.

cc @justbur