### PR TITLE
Fix up helm minibuffer defaults

### DIFF
--- a/evil-collection-helm.el
+++ b/evil-collection-helm.el
@@ -172,6 +172,8 @@
   ;; C-o switches to evil state (again, not useful).
   (evil-collection-define-key '(insert normal) 'helm-map
     (kbd "RET") 'helm-maybe-exit-minibuffer
+    (kbd "M-v") 'helm-previous-page
+    (kbd "C-v") 'helm-next-page
     (kbd "C-p") 'helm-previous-line
     (kbd "C-n") 'helm-next-line
     (kbd "C-o") 'helm-next-source)
@@ -180,6 +182,8 @@
     (kbd "<tab>") 'helm-select-action   ; TODO: Ivy has "ga".
     (kbd "[") 'helm-previous-source
     (kbd "]") 'helm-next-source
+    (kbd "C-u") 'helm-previous-page
+    (kbd "C-d") 'helm-next-page
     "gk" 'helm-previous-source
     "gj" 'helm-next-source
     (kbd "(") 'helm-prev-visible-mark

--- a/evil-collection-helm.el
+++ b/evil-collection-helm.el
@@ -178,12 +178,18 @@
     (kbd "C-n") 'helm-next-line
     (kbd "C-o") 'helm-next-source)
 
+  (when evil-want-C-u-scroll
+    (evil-collection-define-key 'normal 'helm-map
+      (kbd "C-u") 'helm-previous-page))
+
+  (when evil-want-C-d-scroll
+    (evil-collection-define-key 'normal 'helm-map
+      (kbd "C-d") 'helm-next-page))
+
   (evil-collection-define-key 'normal 'helm-map
     (kbd "<tab>") 'helm-select-action   ; TODO: Ivy has "ga".
     (kbd "[") 'helm-previous-source
     (kbd "]") 'helm-next-source
-    (kbd "C-u") 'helm-previous-page
-    (kbd "C-d") 'helm-next-page
     "gk" 'helm-previous-source
     "gj" 'helm-next-source
     (kbd "(") 'helm-prev-visible-mark

--- a/evil-collection-helm.el
+++ b/evil-collection-helm.el
@@ -165,6 +165,17 @@
     "%" 'helm-ff-run-query-replace-regexp
     "D" 'helm-ff-run-delete-file)       ; Ivy has "D".
 
+  ;; These helm bindings should always exist, the evil equivalents do
+  ;; nothing useful in the minibuffer (error or pure failure).
+  ;; RET can't do a second line in the minibuffer.
+  ;; The C-n/C-p completions error with 'helm in helm' session.
+  ;; C-o switches to evil state (again, not useful).
+  (evil-collection-define-key '(insert normal) 'helm-map
+    (kbd "RET") 'helm-maybe-exit-minibuffer
+    (kbd "C-p") 'helm-previous-line
+    (kbd "C-n") 'helm-next-line
+    (kbd "C-o") 'helm-next-source)
+
   (evil-collection-define-key 'normal 'helm-map
     (kbd "<tab>") 'helm-select-action   ; TODO: Ivy has "ga".
     (kbd "[") 'helm-previous-source


### PR DESCRIPTION
This makes the minibuffer usable with a few frequently used helm bindings - the unbound evil equivalents either error out or have no effect, so it is best to restore to the default Emacs style binds.