### PR TITLE
Don't byte-compile neotree

### DIFF
--- a/evil-collection-neotree.el
+++ b/evil-collection-neotree.el
@@ -1,4 +1,4 @@
-;;; evil-collection-neotree.el --- Evil bindings for neotree -*- lexical-binding: t -*-
+;;; evil-collection-neotree.el --- Evil bindings for neotree -*- lexical-binding: t; no-byte-compile: t; -*-
 
 ;; Copyright (C) 2017 Pierre Neidhardt
 


### PR DESCRIPTION
This prevents the byte-compiler from trying to expand neotree-make-executor at
compile time when neotree might not be available.

Fixes #158