### PR TITLE
vdiff: don't bind fold keys, which are handled by evil-fold-list

### DIFF
--- a/evil-collection-vdiff.el
+++ b/evil-collection-vdiff.el
@@ -32,15 +32,8 @@
 
 (defun evil-collection-vdiff-setup ()
   "Set up `evil' bindings for `vdiff-mode'."
-
   (dolist (mode '(vdiff-mode vdiff-3way-mode))
     (evil-define-minor-mode-key 'normal mode
-      "zc" 'vdiff-close-fold
-      "zM" 'vdiff-close-all-folds
-      "zo" 'vdiff-open-fold
-      "zR" 'vdiff-open-all-folds
-      "go" 'vdiff-receive-changes
-      "gp" 'vdiff-send-changes
       "]c" 'vdiff-next-hunk
       "[c" 'vdiff-previous-hunk)
 


### PR DESCRIPTION
Refs https://github.com/emacs-evil/evil-collection/pull/179, https://github.com/emacs-evil/evil/pull/1072

@bling I've removed the `go` and `gp` binding because `do` and `dp` are already bound, and are in-line with vim