### PR TITLE
deadgrep: Add bindings (q, ZZ, ZQ) to quit Deadgrep buffer

### DIFF
--- a/evil-collection-deadgrep.el
+++ b/evil-collection-deadgrep.el
@@ -39,7 +39,12 @@
     "gr" 'deadgrep-restart
     (kbd "C-j") 'deadgrep-forward
     (kbd "C-k") 'deadgrep-backward
-    (kbd "TAB") 'deadgrep-toggle-file-results))
+    (kbd "TAB") 'deadgrep-toggle-file-results
+    ;; Quit
+    "q" 'quit-window
+    "ZZ" 'quit-window
+    "ZQ" 'evil-quit
+    ))
 
 (provide 'evil-collection-deadgrep)
 ;;; evil-collection-deadgrep.el ends here


### PR DESCRIPTION
First of all, thank you for the great collection. Ever since I discovered this, I have been able to remove most of the bindings I had in my config for modes such as IBuffer and Help.

I also noticed that the configuration for Deadgrep mode does not provide bindings to quit the window. This makes it unfortunately annoying to get out of the Deadgrep buffer right now.

I have added them in this PR. I'm not really sure whether the `ZQ` binding is needed here, but I added it for the sake of consistency with the other modes.

Thank you in advance!