### PR TITLE
Add beginend

### DIFF
--- a/evil-collection-beginend.el
+++ b/evil-collection-beginend.el
@@ -30,6 +30,8 @@
 (require 'evil-collection)
 (require 'beginend nil t)
 
+(defvar beginend-modes)
+
 (defun evil-collection-beginend-setup ()
   "Set up `evil' bindings for `beginend'."
   (mapc (lambda (pair)
@@ -37,8 +39,8 @@
                  (mode-name (symbol-name mode))
                  (map-name (intern (format "%s-map" mode-name))))
             (evil-collection-define-key 'normal map-name
-              "gg" 'beginning-of-buffer
-              "G" 'end-of-buffer)))
+              "gg" (command-remapping 'beginning-of-buffer nil (eval map-name))
+              "G" (command-remapping 'end-of-buffer nil (eval map-name)))))
         beginend-modes))
 
 (provide 'evil-collection-beginend)

--- a/evil-collection-beginend.el
+++ b/evil-collection-beginend.el
@@ -1,0 +1,46 @@
+;;; evil-collection-beginend.el --- Bindings for `beginend-mode' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2018 James Nguyen
+
+;; Author: James Nguyen <james@jojojames.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <ambrevar@gmail.com>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: evil, emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for `beginend-mode'
+
+;;; Code:
+(require 'evil-collection)
+(require 'beginend)
+
+(defun evil-collection-beginend-setup ()
+  "Set up `evil' bindings for `beginend'."
+  (mapc (lambda (pair)
+          (let* ((mode (cdr pair))
+                 (mode-name (symbol-name mode))
+                 (map-name (intern (format "%s-map" mode-name))))
+            (evil-collection-define-key 'normal map-name
+              "gg" 'beginning-of-buffer
+              "G" 'end-of-buffer)
+            ))
+        beginend-modes))
+
+(provide 'evil-collection-beginend)
+;;; evil-collection-beginend.el ends here

--- a/evil-collection-beginend.el
+++ b/evil-collection-beginend.el
@@ -28,7 +28,7 @@
 
 ;;; Code:
 (require 'evil-collection)
-(require 'beginend)
+(require 'beginend nil t)
 
 (defun evil-collection-beginend-setup ()
   "Set up `evil' bindings for `beginend'."
@@ -38,8 +38,7 @@
                  (map-name (intern (format "%s-map" mode-name))))
             (evil-collection-define-key 'normal map-name
               "gg" 'beginning-of-buffer
-              "G" 'end-of-buffer)
-            ))
+              "G" 'end-of-buffer)))
         beginend-modes))
 
 (provide 'evil-collection-beginend)

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -67,6 +67,7 @@ or evil-collection.")
     anaconda-mode
     arc-mode
     avy
+    beginend
     bookmark
     (buff-menu "buff-menu")
     calc


### PR DESCRIPTION
[Beginend](https://github.com/DamienCassou/beginend) is a great package which replaces the normal `M-<` and `M->` bindings with better ones that make sense in the context of the current mode. For example, `M-<` in a Magit status buffer goes to the  first section instead of the first line. (There are numerous other modes supported.)

In Evil, `gg` and `G` has been bound to `evil-goto-first-line` and `evil-goto-line` respectively. It made sense to me that if I have `beginend-mode` enable for my Emacs, I would want `gg` and `G` to behave like `M-<` and `M->` does in the normal Emacs state. With this commit, I have added support for that behaviour.

I'm not really sure whether the current implementation is the best way to do it. But there are a few advantages we get: namely pressing `gg` once takes you to the overridden beginning of buffer. Pressing it again takes you the actual beginning of buffer. And repeated presses behave as expected. (This is how `beginend` behaves with `M-<`.)

I'll be open to suggestions for modifications, of course.

Thank you in advance.