### PR TITLE
diff-mode: allow quitting with 'q'

### DIFF
--- a/evil-collection-diff-mode.el
+++ b/evil-collection-diff-mode.el
@@ -99,6 +99,8 @@ current file instead."
     "gj" 'diff-hunk-next
     "gk" 'diff-hunk-prev
 
+    "q" 'quit-window
+
     "\\" 'read-only-mode) ; magit has "\"
 
   (evil-collection-define-key 'motion 'diff-mode-map


### PR DESCRIPTION
Seems to be standard for bindings for other modes

This is a fix for #193 