### PR TITLE
add 'gr' as a bind for `package-menu-refresh' in package-menu-mode

### DIFF
--- a/evil-collection-package-menu.el
+++ b/evil-collection-package-menu.el
@@ -40,6 +40,7 @@
     "i" 'package-menu-mark-install
     "U" 'package-menu-mark-upgrades
     "d" 'package-menu-mark-delete
+    "gr" 'package-menu-refresh
 
     ;; undo
     "u" 'package-menu-mark-unmark


### PR DESCRIPTION
Adds 'gr' bind in normal mode in order to be able to call `package-menu-refresh' when in package-menu-mode.  In default emacs bindings, 'r' is used to refresh, but I thought 'gr' would be more appropriate based on the conventions in the evil-collection README. 