### PR TITLE
Let "dd" mark line for deletion in wgrep

### DIFF
--- a/evil-collection-wgrep.el
+++ b/evil-collection-wgrep.el
@@ -43,6 +43,7 @@
   (evil-collection-define-key 'normal 'wgrep-mode-map
     "ZQ" 'wgrep-abort-changes
     "ZZ" 'wgrep-finish-edit
+    "dd" 'wgrep-mark-deletion
     (kbd "<escape>") 'wgrep-exit))
 
 (provide 'evil-collection-wgrep)


### PR DESCRIPTION
I think this is a decent binding since dd deletes a line normally and this will mark a line to be deleted when wgrep finishes.