### PR TITLE
Add mention of other packages loading evil to readme

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -47,7 +47,7 @@ more.
 
    : (evil-collection-init 'calendar)
 
-   The list of supported modes is configured by ~~evil-collection-mode-list~~.
+   The list of supported modes is configured by ~evil-collection-mode-list~.
 
    ~evil-collection~ assumes ~evil-want-keybinding~ is set to nil
    and ~evil-want-integration~ is set to t before loading ~evil~ and ~evil-collection.~

--- a/readme.org
+++ b/readme.org
@@ -49,8 +49,10 @@ more.
 
    The list of supported modes is configured by ~evil-collection-mode-list~.
 
-   ~evil-collection~ assumes ~evil-want-keybinding~ is set to nil
-   and ~evil-want-integration~ is set to t before loading ~evil~ and ~evil-collection.~
+   ~evil-collection~ assumes ~evil-want-keybinding~ is set to nil and
+   ~evil-want-integration~ is set to t before loading ~evil~ and
+   ~evil-collection.~ Note some other packages may load evil (e.g. evil-leader)
+   so bear that in mind when determining when to set the variables.
 
    See https://github.com/emacs-evil/evil-collection/issues/60 and https://github.com/emacs-evil/evil/pull/1087
    for more details.


### PR DESCRIPTION
See the following: https://github.com/emacs-evil/evil-collection/issues/215

I ended up just mentioning it right after it says when those variables must be set. If you rather it be an addition to the Faq, let me know.