### PR TITLE
Fix RET in debug-mode-map for emacs 27.

### DIFF
--- a/evil-collection-debug.el
+++ b/evil-collection-debug.el
@@ -42,7 +42,9 @@
     ;; motion
     (kbd "<tab>") 'forward-button
     (kbd "S-<tab>") 'backward-button
-    (kbd "<return>") 'debug-help-follow
+    (kbd "<return>") (if (< emacs-major-version 27)
+                         'debug-help-follow
+                       'backtrace-help-follow-symbol)
     (kbd "SPC") 'next-line
 
     "R" 'debugger-record-expression


### PR DESCRIPTION
Commit https://github.com/emacs-mirror/emacs/commit/e09120d68694272ea5efbe13b16936b4382389d8 introduced this change:
```
(debug-help-follow): Remove.  Move body of this function to
'backtrace-help-follow-symbol' in backtrace.el.
```