### PR TITLE
Fix non-prefix key errors

### DIFF
--- a/evil-collection-dired.el
+++ b/evil-collection-dired.el
@@ -35,6 +35,11 @@
 ;;;###autoload
 (defun evil-collection-dired-setup ()
   "Set up `evil' bindings for `dired'."
+  
+  (evil-collection-define-key 'normal 'dired-mode-map
+    "[" nil
+    "]" nil)
+  
   (evil-collection-define-key 'normal 'dired-mode-map
     "q" 'quit-window
     "j" 'dired-next-line

--- a/evil-collection-edebug.el
+++ b/evil-collection-edebug.el
@@ -42,9 +42,10 @@
 
   (add-hook 'edebug-mode-hook #'evil-normalize-keymaps)
 
-  (evil-collection-define-key nil 'edebug-mode-map
+  (evil-collection-define-key 'normal 'edebug-mode-map
     "g" nil
-    "G" nil)
+    "E" nil                         
+    "W" nil)
 
   ;; FIXME: Seems like other minor modes will readily clash with `edebug'.
   ;; `lispyville' and `edebug' 's' key?


### PR DESCRIPTION
byte compilation results in 
```
evil-collection error: (error Key sequence g o starts with non-prefix key g)
```