### PR TITLE
Load lsp-ui-imenu instead of lsp-ui

### DIFF
--- a/evil-collection-lsp-ui-imenu.el
+++ b/evil-collection-lsp-ui-imenu.el
@@ -27,7 +27,7 @@
 ;;; Bindings for `lsp-ui-imenu-mode'.
 
 ;;; Code:
-(require 'lsp-ui nil t)
+(require 'lsp-ui-imenu nil t)
 (require 'evil-collection)
 
 (defconst evil-collection-lsp-ui-imenu-mode-maps '(lsp-ui-imenu-mode-map))


### PR DESCRIPTION
This causes lsp-ui to be loaded twice.

To reproduce (in vanilla emacs):

```elisp
(with-eval-after-load 'lsp-ui-imenu ; simulates evil-collection-lsp-ui-imenu
  (require 'lsp-ui))

(with-eval-after-load 'lsp-ui
  (message "hello"))

(require 'lsp-ui)  ;; -> "hello [2 times]"
```

This complicates configuring lsp-ui with `with-eval-after-load`.