### PR TITLE
notmuch: Bind "|" to notmuch-show-pipe-message in notmuch-tree.

### DIFF
--- a/evil-collection-notmuch.el
+++ b/evil-collection-notmuch.el
@@ -193,6 +193,7 @@
     "[[" 'notmuch-tree-prev-message
     (kbd "C-k") 'notmuch-tree-prev-thread
     (kbd "C-j") 'notmuch-tree-next-thread
+    "|" 'notmuch-show-pipe-message
     "-" 'notmuch-tree-remove-tag
     "+" 'notmuch-tree-add-tag
     "*" 'notmuch-tree-tag-thread


### PR DESCRIPTION
this is also what would be the case in the emacs state, so it is just a matter of making things consistent