### PR TITLE
Add tablist

### DIFF
--- a/evil-collection-docker.el
+++ b/evil-collection-docker.el
@@ -25,8 +25,6 @@
 (require 'docker nil t)
 (require 'evil-collection)
 
-(defvar tablist-mode-filter-map)
-
 (defconst evil-collection-docker-maps '(docker-container-mode-map
                                         docker-image-mode-map
                                         docker-machine-mode-map
@@ -51,9 +49,6 @@
     "b"  'docker-container-shell-popup
     "d"  'docker-container-diff-popup
     "f"  'docker-container-find-file-popup
-    "g/" tablist-mode-filter-map
-    "gr" 'revert-buffer
-    "q"  'quit-window
     "r"  'docker-container-rename-selection)
 
   (evil-collection-define-key 'normal 'docker-image-mode-map
@@ -64,10 +59,7 @@
     "I"  'docker-image-inspect-popup
     "P"  'docker-image-push-popup
     "R"  'docker-image-run-popup
-    "T"  'docker-image-tag-selection
-    "g/" tablist-mode-filter-map
-    "gr" 'revert-buffer
-    "q"  'quit-window)
+    "T"  'docker-image-tag-selection)
 
   (evil-collection-define-key 'normal 'docker-machine-mode-map
     ";"  'docker-machine-ls-popup
@@ -77,24 +69,18 @@
     "E"  'docker-machine-env-popup
     "O"  'docker-machine-stop-popup
     "R"  'docker-machine-restart-popup
-    "S"  'docker-machine-start-popup
-    "gr" 'revert-buffer
-    "q"  'quit-window)
+    "S"  'docker-machine-start-popup)
 
   (evil-collection-define-key 'normal 'docker-network-mode-map
     ";"  'docker-network-ls-popup
     "?"  'docker-network-help-popup
-    "D"  'docker-network-rm-popup
-    "gr" 'revert-buffer
-    "q"  'quit-window)
+    "D"  'docker-network-rm-popup)
 
   (evil-collection-define-key 'normal 'docker-volume-mode-map
     ";"  'docker-volume-ls-popup
     "?"  'docker-volume-help-popup
     "D"  'docker-volume-rm-popup
-    "d"  'docker-volume-dired-selection
-    "gr" 'revert-buffer
-    "q"  'quit-window))
+    "d"  'docker-volume-dired-selection))
 
 (provide 'evil-collection-docker)
 

--- a/evil-collection-tablist.el
+++ b/evil-collection-tablist.el
@@ -1,0 +1,62 @@
+;;; evil-collection-tablist.el --- Evil bindings for Tablist -*- lexical-binding: t -*-
+
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: evil, tablist, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil bindings for Tablist.
+
+;;; Code:
+(require 'tablist nil t)
+(require 'evil-collection)
+
+(defconst evil-collection-tablist-maps '(tablist-mode-map tablist-minor-mode-map))
+
+;;;###autoload
+(defun evil-collection-tablist-setup ()
+  "Set up `evil' bindings for `tablist'."
+
+  (evil-collection-define-key 'normal 'tablist-mode-map
+    (kbd "RET") 'tablist-find-entry
+    "d" 'tablist-flag-forward
+    "f" 'tablist-find-entry
+    "D" 'tablist-do-delete
+    "C" 'tablist-do-copy
+    "R" 'tablist-do-rename
+    "x" 'tablist-do-flagged-delete)
+
+  (evil-collection-define-key 'normal 'tablist-minor-mode-map
+    "<"  'tablist-shrink-column
+    ">"  'tablist-enlarge-column
+    "U"  'tablist-unmark-all-marks
+    "\t" 'tablist-forward-column
+    "g%" tablist-mode-regexp-map
+    "g*" tablist-mode-mark-map
+    "g/" tablist-mode-filter-map
+    "gr" 'tablist-revert
+    "k"  'tablist-do-kill-lines
+    "m"  'tablist-mark-forward
+    "q"  'tablist-quit
+    "s"  'tablist-sort
+    "t"  'tablist-toggle-marks
+    "u"  'tablist-unmark-forward
+    (kbd "TAB") 'tablist-forward-column
+    [backtab] 'tablist-backward-column))
+
+(provide 'evil-collection-tablist)
+;;; evil-collection-tablist.el ends here

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -212,8 +212,8 @@ through removing their entry from `evil-collection-mode-list'."
     restclient
     rjsx-mode
     robe
-    ruby-mode
     rtags
+    ruby-mode
     simple
     slime
     tablist

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -216,6 +216,7 @@ through removing their entry from `evil-collection-mode-list'."
     rtags
     simple
     slime
+    tablist
     (term term ansi-term multi-term)
     tetris
     tide


### PR DESCRIPTION
Hello,

Before you merge this I need guidance: this does not work.

Here is how `docker-image-mode` works:

``` elisp
(define-derived-mode docker-image-mode tabulated-list-mode "Images Menu"
  "Major mode for handling a list of docker images."
  (setq tabulated-list-format [("Repository" 30 t)("Tag" 20 t)("Id" 16 t)("Created" 23 t)("Size" 10 docker-image-human-size-predicate)])
  (setq tabulated-list-padding 2)
  (setq tabulated-list-sort-key docker-image-default-sort-key)
  (add-hook 'tabulated-list-revert-hook 'docker-image-refresh nil t)
  (tabulated-list-init-header)
  (tablist-minor-mode))
```

It's a major mode that enables the minor mode `tablist-minor-mode`.

Any idea what I am missing for it to work? Should I call `evil-collection-tablist-setup` from within `evil-collection-docker-setup` ?

Repeating the bindings for all docker major modes looks overkill.