### PR TITLE
Fix "h" in grep mode

### DIFF
--- a/evil-collection-grep.el
+++ b/evil-collection-grep.el
@@ -36,6 +36,7 @@
 (defun evil-collection-grep-setup ()
   "Set up `evil' bindings for `grep'."
   (evil-collection-define-key 'normal 'grep-mode-map
+    "h" #'evil-backward-char
     "n" 'evil-search-next
     "\C-j" 'next-error-no-select
     "\C-k" 'previous-error-no-select))


### PR DESCRIPTION
By default this is bound to describe-mode, which is easily accessible
through other means.
