### PR TITLE
Fix recompile binding for grep mode

### DIFF
--- a/evil-collection-compile.el
+++ b/evil-collection-compile.el
@@ -30,32 +30,35 @@
 (require 'evil-collection)
 (require 'compile)
 
-(defconst evil-collection-compile-maps '(compilation-mode-map))
+(defconst evil-collection-compile-maps
+  '(compilation-mode-map compilation-minor-mode-map))
 
 ;;;###autoload
 (defun evil-collection-compile-setup ()
   "Set up `evil' bindings for `compile'."
   (evil-set-initial-state 'compilation-mode 'normal)
 
-  (evil-collection-define-key 'normal 'compilation-mode-map
-    "g?" 'describe-mode
-    "?" evil-collection-evil-search-backward
-    "gg" 'evil-goto-first-line
-    "0" 'evil-digit-argument-or-evil-beginning-of-line
-    [mouse-2] 'compile-goto-error
-    [follow-link] 'mouse-face
-    (kbd "RET") 'compile-goto-error
+  (dolist (map evil-collection-compile-maps)
+    (evil-collection-define-key 'normal map
+      "g?" 'describe-mode
+      "?" evil-collection-evil-search-backward
+      "gg" 'evil-goto-first-line
+      "0" 'evil-digit-argument-or-evil-beginning-of-line
+      [mouse-2] 'compile-goto-error
+      [follow-link] 'mouse-face
+      (kbd "RET") 'compile-goto-error
 
-    "go" 'compilation-display-error
-    (kbd "S-<return>") 'compilation-display-error
+      "h" #'evil-backward-char
+      "go" 'compilation-display-error
+      (kbd "S-<return>") 'compilation-display-error
 
-    "gj" 'compilation-next-error
-    "gk" 'compilation-previous-error
-    (kbd "C-j") 'compilation-next-error
-    (kbd "C-k") 'compilation-previous-error
-    "[[" 'compilation-previous-file
-    "]]" 'compilation-next-file
-    "gr" 'recompile))
+      "gj" 'compilation-next-error
+      "gk" 'compilation-previous-error
+      (kbd "C-j") 'compilation-next-error
+      (kbd "C-k") 'compilation-previous-error
+      "[[" 'compilation-previous-file
+      "]]" 'compilation-next-file
+      "gr" 'recompile)))
 
 (provide 'evil-collection-compile)
 ;;; evil-collection-compile.el ends here

--- a/evil-collection-grep.el
+++ b/evil-collection-grep.el
@@ -36,7 +36,6 @@
 (defun evil-collection-grep-setup ()
   "Set up `evil' bindings for `grep'."
   (evil-collection-define-key 'normal 'grep-mode-map
-    "h" #'evil-backward-char
     "n" 'evil-search-next
     "\C-j" 'next-error-no-select
     "\C-k" 'previous-error-no-select))


### PR DESCRIPTION
It should be "gr" rather than "g". While this fix works, other bindings like `gg` remain broken for example. What's the correct way to make `g <x>` be forwarded to the appropriate normal mode command?