### PR TITLE
Load evil-collection-custom after cus-edit

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -126,7 +126,7 @@ through removing their entry from `evil-collection-mode-list'."
     comint
     company
     compile
-    custom
+    (custom cus-edit)
     cus-theme
     daemons
     deadgrep


### PR DESCRIPTION
The cus-edit.el file contains the relevant map/functions, not custom.el.