### PR TITLE
Add bindings for dired-subtree

### DIFF
--- a/modes/dired/evil-collection-dired.el
+++ b/modes/dired/evil-collection-dired.el
@@ -189,7 +189,7 @@
     ";e" 'epa-dired-do-encrypt)
 
     ;; dired-subtree commands
-    (when (featurep 'dired-subtree)
+    (with-eval-after-load 'dired-subtree
 	(evil-collection-define-key 'normal 'dired-mode-map
 	    "I" 'dired-subtree-toggle
 	    (kbd "TAB") 'dired-subtree-cycle

--- a/modes/dired/evil-collection-dired.el
+++ b/modes/dired/evil-collection-dired.el
@@ -191,7 +191,6 @@
     ;; dired-subtree commands
     (with-eval-after-load 'dired-subtree
 	(evil-collection-define-key 'normal 'dired-mode-map
-	    "I" 'dired-subtree-toggle
 	    (kbd "TAB") 'dired-subtree-cycle
 	    "gh" 'dired-subtree-up
 	    "gl" 'dired-subtree-down

--- a/modes/dired/evil-collection-dired.el
+++ b/modes/dired/evil-collection-dired.el
@@ -186,7 +186,17 @@
     ";d" 'epa-dired-do-decrypt
     ";v" 'epa-dired-do-verify
     ";s" 'epa-dired-do-sign
-    ";e" 'epa-dired-do-encrypt))
+    ";e" 'epa-dired-do-encrypt)
+
+    ;; dired-subtree commands
+    (when (featurep 'dired-subtree)
+	(evil-collection-define-key 'normal 'dired-mode-map
+	    "I" 'dired-subtree-toggle
+	    (kbd "TAB") 'dired-subtree-cycle
+	    "gh" 'dired-subtree-up
+	    "gl" 'dired-subtree-down
+	    (kbd "M-j") 'dired-subtree-next-sibling
+	    (kbd "M-k") 'dired-subtree-previous-sibling)))
 
 (provide 'evil-collection-dired)
 ;;; evil-collection-dired.el ends here


### PR DESCRIPTION
`dired-subtree` allows the insertion of a subtree in place instead of at the bottom of the buffer, as `dired-maybe-insert-subdir` would. Unfortunately `dired-subtree` does not come with a minor mode to cleanly separate keybindings, so I inserted a `featurep` check if `dired-subtree` is available, as it makes sense to overwrite one or more bindings from `evil-dired`.

`dired-subtree` is interesting by itself as it makes navigating directories a bit easier, but it is also a requirement for `dired-sidebar`, a candidate for addition to `evil-collection`.

P.S.: This is my first proper pull request, please advise if I'm doing something wrong.