### PR TITLE
Improve tablist bindings

### DIFF
--- a/modes/tablist/evil-collection-tablist.el
+++ b/modes/tablist/evil-collection-tablist.el
@@ -53,7 +53,7 @@
     "g*" tablist-mode-mark-map
     "g/" tablist-mode-filter-map
     "gr" 'tablist-revert
-    "D"  'tablist-do-kill-lines
+    "K"  'tablist-do-kill-lines
     "m"  'tablist-mark-forward
     "q"  'tablist-quit
     "s"  'tablist-sort


### PR DESCRIPTION
This move `tablist-do-kill-lines` to `K` like in `dired` and `ibuffer`.