### PR TITLE
Fix conflicting keybindings in gnus configuration

### DIFF
--- a/modes/gnus/evil-collection-gnus.el
+++ b/modes/gnus/evil-collection-gnus.el
@@ -133,7 +133,6 @@
     "E" 'gnus-summary-mark-as-expirable
     (kbd "M-u") 'gnus-summary-clear-mark-forward
     (kbd "M-U") 'gnus-summary-clear-mark-backward
-    "k" 'gnus-summary-kill-same-subject-and-select
     (kbd "C-k") 'gnus-summary-kill-same-subject
     (kbd "M-C-k") 'gnus-summary-kill-thread
     (kbd "M-C-l") 'gnus-summary-lower-thread

--- a/modes/gnus/evil-collection-gnus.el
+++ b/modes/gnus/evil-collection-gnus.el
@@ -133,7 +133,6 @@
     "E" 'gnus-summary-mark-as-expirable
     (kbd "M-u") 'gnus-summary-clear-mark-forward
     (kbd "M-U") 'gnus-summary-clear-mark-backward
-    (kbd "C-k") 'gnus-summary-kill-same-subject
     (kbd "M-C-k") 'gnus-summary-kill-thread
     (kbd "M-C-l") 'gnus-summary-lower-thread
     "e" 'gnus-summary-edit-article


### PR DESCRIPTION
There were two different `C-k` keybindings, so I removed the one for `gnus-summary-kill-same-subject`. Now `C-j` and `C-k` behave in a similar way.

The `k` keybinding was conflicting with `evil-previous-line`, so I removed that one too.