### PR TITLE
vterm-exit-functions now sends event as 2nd arg.

### DIFF
--- a/modes/vterm/evil-collection-vterm.el
+++ b/modes/vterm/evil-collection-vterm.el
@@ -40,7 +40,7 @@ Moving cursor backwards is the default vim behavior but
 it is not appropriate in some cases like terminals."
   (setq-local evil-move-cursor-back nil))
 
-(defun evil-collection-vterm-exit-function (buffer)
+(defun evil-collection-vterm-exit-function (buffer &optional event)
   "Automatically kill `vterm' buffer on exit."
   (when buffer
     (kill-buffer buffer)))


### PR DESCRIPTION
emacs-libvterm@376db7cf416 had a breaking change for
`vterm-exit-functions` which sends the event as the second argument.