### PR TITLE
Do not override `zb` in outline mode.

### DIFF
--- a/modes/outline/evil-collection-outline.el
+++ b/modes/outline/evil-collection-outline.el
@@ -65,7 +65,7 @@ mode."
     ;; "zb" 'outline-show-branches
     ;; "zo" 'outline-hide-other
     "zB" 'outline-hide-body ; Hide all bodies, Emacs has "C-c C-t".
-    "zb" 'outline-hide-entry ; Hide current body, Emacs has "C-c C-c".
+    "zE" 'outline-hide-entry ; Hide current body, Emacs has "C-c C-c".
     "ze" 'outline-show-entry ; Show current body only, not subtree, reverse of outline-hide-entry, Emacs has "C-c C-e".
     "zl" 'outline-hide-leaves ; Like `outline-hide-body' but for current subtree only, Emacs has "C-c C-l".
     "zK" 'outline-show-branches ; Show all children recursively but no body.  Emacs has "C-c C-k".


### PR DESCRIPTION
`zb` is usually bound to `evil-scroll-line-to-bottom`. By moving `outline-hide-entry` to `zE`, you also get more consistency because `ze` is bound to `outline-show-entry`.

It fixes https://github.com/emacs-evil/evil-collection/issues/292