### PR TITLE
Replace `g]` with `g TAB`. Eliminate `g[`.

### DIFF
--- a/modes/help/evil-collection-help.el
+++ b/modes/help/evil-collection-help.el
@@ -44,10 +44,8 @@
     (kbd "C-f") 'scroll-up-command
     (kbd "C-b") 'scroll-down-command
     (kbd "<tab>") 'forward-button
+    (kbd "g TAB") 'forward-button
     (kbd "<backtab>") 'backward-button
-    ;; This exists because <tab> is recognized as C-i on terminals.
-    "g]" 'forward-button
-    "g[" 'backward-button
 
     (kbd "C-o") 'help-go-back
     (kbd "C-i") 'help-go-forward

--- a/modes/info/evil-collection-info.el
+++ b/modes/info/evil-collection-info.el
@@ -43,10 +43,8 @@
     "l" 'evil-forward-char
     "h" 'evil-backward-char
     (kbd "<tab>") 'Info-next-reference
-    (kbd "S-<tab>") 'Info-prev-reference
-    ;; This exists because <tab> is recognized as C-i on terminals.
-    "g]" 'Info-next-reference
-    "g[" 'Info-prev-reference
+    (kbd "g TAB") 'Info-next-reference
+    (kbd "<backtab>") 'Info-prev-reference
 
     ;; From evil-integration.el.
     "0" 'evil-digit-argument-or-evil-beginning-of-line

--- a/readme.org
+++ b/readme.org
@@ -190,8 +190,8 @@ more.
          - Tab key is recognized as ~<tab>~ in GUI and ~TAB~ in terminal.
            ~TAB~ equals ~C-i~.
          - Since ~C-i~ is bound to jumping forward for vim compatibility,
-           bind ~g[~ and ~g]~ to the functions that Shift+Tab and Tab
-           are bound to on GUI for terminal compatibility.
+           bind ~g TAB~ to the function that ~<tab>~ is bound to for
+           terminal compatibility.
        - Enter key
          - Enter key is recognized as ~<return>~ in GUI and ~RET~ in terminal.
            ~RET~ equals ~Ctrl+m~.


### PR DESCRIPTION
I used `g[` because I thought `<backtab>` was impossible on linux virtual terminal. However, I just had to make a new keymap that inherits /usr/share/keymaps/i386/qwerty/us.map.gz to make emacs
recognize shift+tab as `<backtab>` on linux virtual terminal.

linux kernel community distributes kbd package which contains /usr/share/keymaps/i386/qwerty/us.map.gz which maps shift+tab to alt+tab. I don't see a reason to map shift+tab to alt+tab anywehre. I suspect somebody was trying to sabotage linux virtual
terminal.

Binding `g TAB` to the function that `<tab>` is bound to makes sense now because pressing `g TAB` and Shift+Tab is easy.

By default, Right Alt is mapped to AltGr, and Shift+Tab is mapped to Alt+Tab on linux virtual terminal. If you want to map Right Alt to Alt and Shift+Tab to Shift+Tab on linux virtual terminal, follow the steps below.

* Create /usr/share/keymaps/i386/qwerty/better-us.map.gz
```
include "us.map"
include "linux-with-two-alt-keys"

alt keycode 15 = Meta_Tab
shift keycode 15 = F26
string F26 = "\033[Z"
```
* Set keymap to `better-us` in the init script that sets linux console keymap during boot.
* Reboot
* After reboot, you will be able to press Right Alt and Shift+Tab in emacs on linux console.