### PR TITLE
Helpful: add binding for visiting reference

### DIFF
--- a/modes/helpful/evil-collection-helpful.el
+++ b/modes/helpful/evil-collection-helpful.el
@@ -40,6 +40,7 @@
     ;; motion
     (kbd "<tab>") 'forward-button
     (kbd "<backtab>") 'backward-button
+    (kbd "RET") 'helpful-visit-reference
 
     ;; The following bindings don't do what they are supposed to. "go" should open
     ;; in the same window and "gO" should open in a different one.


### PR DESCRIPTION
There wasn't a binding for `helpful-visit-reference`, so I added it.