### PR TITLE
Add `g TAB` as a substitute on terminal for Tab.

### DIFF
--- a/modes/help/evil-collection-help.el
+++ b/modes/help/evil-collection-help.el
@@ -46,6 +46,7 @@
     (kbd "<tab>") 'forward-button
     (kbd "<backtab>") 'backward-button
     ;; This exists because <tab> is recognized as C-i on terminals.
+    (kbd "g TAB") 'forward-button
     "g]" 'forward-button
     "g[" 'backward-button
 

--- a/modes/info/evil-collection-info.el
+++ b/modes/info/evil-collection-info.el
@@ -45,6 +45,7 @@
     (kbd "<tab>") 'Info-next-reference
     (kbd "S-<tab>") 'Info-prev-reference
     ;; This exists because <tab> is recognized as C-i on terminals.
+    (kbd "g TAB") 'Info-next-reference
     "g]" 'Info-next-reference
     "g[" 'Info-prev-reference
 

--- a/readme.org
+++ b/readme.org
@@ -189,9 +189,11 @@ more.
        - Tab key
          - Tab key is recognized as ~<tab>~ in GUI and ~TAB~ in terminal.
            ~TAB~ equals ~C-i~.
-         - Since ~C-i~ is bound to jumping forward for vim compatibility,
-           bind ~g[~ and ~g]~ to the functions that Shift+Tab and Tab
-           are bound to on GUI for terminal compatibility.
+         - ~C-i~ is bound to jumping forward for vim compatibility.
+           If Shift+Tab is not relevant, just bind ~g TAB~ to the function
+           that Tab is bound to. If Shift+Tab is relevant, bind ~g]~ and
+           ~g TAB~ to the function that Tab is bound to, and bind ~g[~ to
+           the function that Shift+Tab is bound to for terminal compatibility.
        - Enter key
          - Enter key is recognized as ~<return>~ in GUI and ~RET~ in terminal.
            ~RET~ equals ~Ctrl+m~.


### PR DESCRIPTION
`g TAB` feels intuitive.