### PR TITLE
fix byte-compile errors

### DIFF
--- a/modes/dashboard/evil-collection-dashboard.el
+++ b/modes/dashboard/evil-collection-dashboard.el
@@ -28,7 +28,7 @@
 ;;; Code:
 
 (require 'evil-collection)
-(require 'dashboard)
+(require 'dashboard nil t)
 
 (defconst evil-collection-dashboard-maps '(dashboard-mode-map))
 

--- a/modes/ebuku/evil-collection-ebuku.el
+++ b/modes/ebuku/evil-collection-ebuku.el
@@ -28,8 +28,8 @@
 
 ;;; Code:
 
-(require 'ebuku)
 (require 'evil-collection)
+(require 'ebuku nil t)
 
 
 ;;;###autoload


### PR DESCRIPTION
Recently introduced evil-collection-ebuku.el and evil-collection-dashboard.el require third-party packages directly, which causes byte-compile error when install from MELPA.


----

#