### PR TITLE
Bind evil-mc-cursors-map to `gC`

### DIFF
--- a/modes/evil-mc/evil-collection-evil-mc.el
+++ b/modes/evil-mc/evil-collection-evil-mc.el
@@ -31,15 +31,13 @@
 (require 'evil-mc nil t)
 (eval-when-compile (require 'subr-x)) ; `if-let*' and `when-let*'
 
-(defvar evil-mc-map)
-(defconst evil-collection-evil-mc-maps '(evil-mc-mode-map))
+(defvar evil-mc-key-map)
+(defconst evil-collection-evil-mc-maps '(evil-mc-key-map))
 
 (defun evil-collection-evil-mc-clear-keymap (&rest _args)
   "Brute force remove `evil-mc-key-map' from `evil-mode-map-alist'."
-  (evil-collection-when-let*
-      ((evil-mc-map (assq 'evil-mc-mode evil-mode-map-alist)))
-    (setq evil-mode-map-alist
-          (delq evil-mc-map evil-mode-map-alist))))
+  (evil-collection-when-let* ((map (assq 'evil-mc-mode evil-mode-map-alist)))
+    (setq evil-mode-map-alist (delq map evil-mode-map-alist))))
 
 ;;;###autoload
 (defun evil-collection-evil-mc-setup ()
@@ -51,6 +49,9 @@
   ;; details.
   (advice-add 'evil-normalize-keymaps
               :after 'evil-collection-evil-mc-clear-keymap)
+
+  (setq evil-mc-key-map (make-sparse-keymap))
+  (evil-define-key* '(normal visual) evil-mc-key-map (kbd "gz") evil-mc-cursors-map)
 
   ;; https://github.com/gabesoft/evil-mc/issues/70
   (add-hook 'evil-mc-after-cursors-deleted

--- a/modes/evil-mc/evil-collection-evil-mc.el
+++ b/modes/evil-mc/evil-collection-evil-mc.el
@@ -34,10 +34,13 @@
 (defvar evil-mc-key-map)
 (defconst evil-collection-evil-mc-maps '(evil-mc-key-map))
 
-(defun evil-collection-evil-mc-clear-keymap (&rest _args)
+(defun evil-collection-evil-mc-change-keymap (&rest _args)
   "Brute force remove `evil-mc-key-map' from `evil-mode-map-alist'."
   (evil-collection-when-let* ((map (assq 'evil-mc-mode evil-mode-map-alist)))
-    (setq evil-mode-map-alist (delq map evil-mode-map-alist))))
+    (setq evil-mode-map-alist (delq map evil-mode-map-alist))
+    (let ((map (make-sparse-keymap)))
+      (evil-define-key* '(normal visual) map (kbd "gz") evil-mc-cursors-map)
+      (add-to-list 'evil-mode-map-alist '(evil-mc-mode . map)))))
 
 ;;;###autoload
 (defun evil-collection-evil-mc-setup ()
@@ -48,10 +51,7 @@
   ;; See https://github.com/emacs-evil/evil-collection/issues/184 for more
   ;; details.
   (advice-add 'evil-normalize-keymaps
-              :after 'evil-collection-evil-mc-clear-keymap)
-
-  (setq evil-mc-key-map (make-sparse-keymap))
-  (evil-define-key* '(normal visual) evil-mc-key-map (kbd "gz") evil-mc-cursors-map)
+              :after 'evil-collection-evil-mc-change-keymap)
 
   ;; https://github.com/gabesoft/evil-mc/issues/70
   (add-hook 'evil-mc-after-cursors-deleted


### PR DESCRIPTION
Hello,

This follows https://github.com/gabesoft/evil-mc/pull/109, don't merge it yet there are things to sort out before.

For starter, I think https://github.com/emacs-evil/evil-collection/blob/master/modes/evil-mc/evil-collection-evil-mc.el#L34 is weird because there's no `evil-mc-map`. As you see below the keymap is named `evil-mc-key-map`. Also thus there's no `evil-mc-mode-map`?

``` emacs-lisp
(define-minor-mode evil-mc-mode
  "Toggle evil multiple cursors in a single buffer."
  :group 'evil-mc
  :init-value nil
  :keymap evil-mc-key-map
```

1. Should I rename both `evil-mc-map` and `evil-mc-mode-map` to `evil-mc-key-map`? What's the purpose of `evil-collection-evil-mc-maps`?
2. Should I add a defvar for `evil-mc-cursors-map`?
3. What do you think of `gC`? Something else comes to mind?