### PR TITLE
advising mu4e-redraw function

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -330,9 +330,10 @@ keybindings."
   "Initialize evil-mu4e if necessary.
 If mu4e-main-mode is in evil-state-motion-modes, initialization
 is already done earlier."
-    (evil-collection-mu4e-set-state)
-    (evil-collection-mu4e-set-bindings)
-    (add-hook 'mu4e-main-mode-hook 'evil-collection-mu4e-update-main-view))
+  (evil-collection-mu4e-set-state)
+  (evil-collection-mu4e-set-bindings)
+  (advice-add 'mu4e~main-redraw-buffer :after 'evil-collection-mu4e-update-main-view))
+
 
 (provide 'evil-collection-mu4e)
 ;;; evil-collection-mu4e.el ends here

--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -332,7 +332,7 @@ If mu4e-main-mode is in evil-state-motion-modes, initialization
 is already done earlier."
   (evil-collection-mu4e-set-state)
   (evil-collection-mu4e-set-bindings)
-  (advice-add 'mu4e~main-redraw-buffer :after 'evil-collection-mu4e-update-main-view))
+  (add-hook 'mu4e-main-redraw-buffer-hook 'evil-collection-mu4e-update-main-view))
 
 
 (provide 'evil-collection-mu4e)


### PR DESCRIPTION
Hello,

As per https://github.com/djcb/mu/commit/b1369b6ad9f9c1a7e8d363dc8c72b503ffd11753 the method mu4e uses to create the main view buffer has changed. This allows for the update to take place after the new `mu4e~main-redraw-buffer` function.

Addresses https://github.com/emacs-evil/evil-collection/issues/314 https://github.com/emacs-evil/evil-collection/issues/309