### PR TITLE
Change pdf-view first & last page to preserve hscroll

### DIFF
--- a/modes/pdf/evil-collection-pdf.el
+++ b/modes/pdf/evil-collection-pdf.el
@@ -76,16 +76,20 @@
   (interactive "P")
   (if page
       (pdf-view-goto-page page)
-    (pdf-view-last-page)
-    (image-eob)))
+    (let ((hscroll (window-hscroll)))
+      (pdf-view-last-page)
+      (image-eob)
+      (image-set-window-hscroll hscroll))))
 
 (defun evil-collection-pdf-view-goto-first-page (&optional page)
   "`evil' wrapper around `pdf-view-first-page'."
   (interactive "P")
   (if page
       (pdf-view-goto-page page)
-    (pdf-view-first-page)
-    (image-bob)))
+    (let ((hscroll (window-hscroll)))
+      (pdf-view-first-page)
+      (image-bob)
+      (image-set-window-hscroll hscroll))))
 
 ;;;###autoload
 (defun evil-collection-pdf-setup ()


### PR DESCRIPTION
Currently `evil-collection-pdf-view-goto-{first,last}-page` are calling `image-bob` and `image-eob`, which not only scroll to the bottom of the image (pdf page), but they also change the horizontal scrolling to either the left edge of the image or the right edge of the image. This is somewhat unexpected behavior (to me).

My reasoning is:
If you have a book / document that has large margins, you might want to zoom in to maximize your view of the text. Today with pdf-view scrolling through the PDF / flipping pages your centering is preserved. I think the behavior should be similar for going to the first & last pages. Today, if you go the first page you are sent to the top of the first page and you are scrolled all the way to the left side of the page.