### PR TITLE
Info-exit is marked obsolete since 27.1, use quit-window instead

### DIFF
--- a/modes/info/evil-collection-info.el
+++ b/modes/info/evil-collection-info.el
@@ -99,9 +99,9 @@
     "?" evil-collection-evil-search-backward  ; Else this would be `Info-summary'.
 
     ;; quit
-    "q" 'Info-exit
+    "q" 'quit-window
     "ZQ" 'evil-quit
-    "ZZ" 'Info-exit)
+    "ZZ" 'quit-window)
 
   (evil-collection-define-key 'visual 'Info-mode-map
     "l" 'evil-forward-char


### PR DESCRIPTION
@Ambrevar @jojojames 