### PR TITLE
package-menu: add keybinding for package-menu-describe-package

### DIFF
--- a/modes/package-menu/evil-collection-package-menu.el
+++ b/modes/package-menu/evil-collection-package-menu.el
@@ -49,6 +49,8 @@
     ;; execute
     "x" 'package-menu-execute
 
+    "g?" 'package-menu-describe-package
+
     "q" 'quit-window ;; FIXME: Can macros make sense here?
     "ZQ" 'evil-quit
     "ZZ" 'quit-window))


### PR DESCRIPTION
Hi,

I heavily use the function package-menu-describe-package in the package buffer to show a long description of a package, and also to get the hyperlink to access the source code. This function, bound to "?" in emacs mode, is very nice as it can be called anywhere on a package line.

I would like to rebind it to "g?", as it seems to be the practice in other modes to show something related to "show help". And it keeps the "?" shortcut to search backward for text (which is also useful in this mode).

I'm open to any discussion on the validity of this mapping.

Regards,

Nicolas

