### PR TITLE
SPC, DEL, S-SPC scroll binds for DocView

### DIFF
--- a/modes/doc-view/evil-collection-doc-view.el
+++ b/modes/doc-view/evil-collection-doc-view.el
@@ -45,6 +45,9 @@
     (kbd "C-d") 'forward-page
     "j" 'doc-view-next-line-or-next-page
     "k" 'doc-view-previous-line-or-previous-page
+    (kbd "SPC") 'doc-view-scroll-up-or-next-page
+    (kbd "DEL") 'doc-view-scroll-down-or-previous-page
+    (kbd "S-SPC") 'doc-view-scroll-down-or-previous-page
     "gg" 'doc-view-first-page
     "G" 'doc-view-last-page
     "J" 'doc-view-goto-page


### PR DESCRIPTION
Currently getting bound to image-scroll-up and image-scroll-down from evil-collection-image.el. Not sure if it is relevant, but evil-collection-image.el has a TODO referencing this closed issue: https://github.com/emacs-evil/evil-collection/issues/23