### PR TITLE
Add org-present

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -211,6 +211,7 @@ through removing their entry from `evil-collection-mode-list'."
     ;; occur is in replace.el which was built-in before Emacs 26.
     (occur ,(if (<= emacs-major-version 25) "replace" 'replace))
     omnisharp
+    org-present
     osx-dictionary
     outline
     p4

--- a/modes/org-present/evil-collection-org-present.el
+++ b/modes/org-present/evil-collection-org-present.el
@@ -1,0 +1,67 @@
+;;; evil-collection-org-present.el --- Bindings for `org-present' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020 Carla Cao
+
+;; Author: Carla Cao <ccao001@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: evil, emacs, tools, minimalist, presentation
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for`org-present'.
+
+;;; Code:
+(require 'evil-collection)
+(require 'org-present nil t) 
+
+(defvar org-present-mode-map) 
+
+(defconst evil-collection-org-present-maps '(org-present-mode-map))
+
+;;;###autoload
+(defun evil-collection-org-present-setup ()
+  "Set up `evil' bindings for `org-present'."
+  (evil-collection-define-key 'normal 'org-present-mode-map
+    "j" 'org-present-next 
+    "k" 'org-present-prev 
+    "gj" 'org-present-next 
+    "gk" 'org-present-prev 
+    "]]" 'org-present-next 
+    "[[" 'org-present-prev 
+    (kbd "SPC") 'org-present-next 
+    (kbd "S-SPC") 'org-present-prev 
+    (kbd "C-j") 'org-present-next 
+    (kbd "M-j") 'org-present-next 
+    (kbd "C-k") 'org-present-prev 
+    (kbd "M-k") 'org-present-prev 
+    "zi" 'org-present-big
+    "zo" 'org-present-small
+    "+" 'org-present-big
+    "=" 'org-present-big 
+    "-" 'org-present-small 
+    "q" 'org-present-quit 
+    "ZQ" 'org-present-quit
+    "ZZ" 'org-present-quit
+    "r" 'org-present-read-only 
+    "w" 'org-present-read-write 
+    "gg" 'org-present-beginning 
+    "G" 'org-present-end))
+
+(provide 'evil-collection-org-present)
+;;; evil-collection-org-present.el ends here


### PR DESCRIPTION
This is a pull request for #370 

Feel free to edit as you see fit and please do let me know if you have any questions.

I still haven't been able to successfully load the keybindings in my emacs.

I am getting the following error:

```Symbol's value as variable is void: org-emph-re```

I have a feeling this might be an issue with my environment variables and emacs but I'm not sure at the moment.

I have my emacs packages installed with guix except for evil-collection which I installed by cloning this repo and sourcing it in my ```~/.emacs```.

\- Carla