### PR TITLE
tabulated-list: add more bindings

### DIFF
--- a/modes/tabulated-list/evil-collection-tabulated-list.el
+++ b/modes/tabulated-list/evil-collection-tabulated-list.el
@@ -39,7 +39,14 @@
 
   (evil-collection-define-key nil 'tabulated-list-mode-map
     "n" nil
-    "p" nil))
+    "p" nil)
+
+  (evil-set-initial-state 'tabulated-list-mode 'normal)
+  (evil-collection-define-key 'normal 'tabulated-list-mode-map
+    "S" 'tabulated-list-sort
+    "{" 'tabulated-list-narrow-current-column
+    "}" 'tabulated-list-widen-current-column
+    "q" 'quit-window))
 
 (provide 'evil-collection-tabulated-list)
 ;;; evil-collection-tabulated-list.el ends here


### PR DESCRIPTION
The original bindings make no sense.

``` elisp
(evil-collection-define-key nil 'tabulated-list-mode-map
  "n" nil
  "p" nil)
```