### PR TITLE
gnus: R can reply in normal state.

### DIFF
--- a/modes/gnus/evil-collection-gnus.el
+++ b/modes/gnus/evil-collection-gnus.el
@@ -204,16 +204,16 @@
 
     ;; Reply
     "r"         'gnus-summary-reply
+    "R"         'gnus-article-reply-with-original ;; override `evil-replace-state'
 
     ;; Composing
     "C"         'gnus-article-mail
     "cc"        'gnus-article-mail
+    "cf"        'gnus-summary-mail-forward
 
     ;; Actions
     (kbd "C-]") 'gnus-article-refer-article
-    "s"         'gnus-article-show-summary
-    "E"         'gnus-article-read-summary-keys
-    (kbd "C-c C-f") 'gnus-summary-mail-forward)
+    "s"         'gnus-article-show-summary)
 
   (evil-set-initial-state 'gnus-group-mode 'normal)
   (evil-collection-define-key 'normal 'gnus-group-mode-map


### PR DESCRIPTION
In addition,

- Rebind gnus-summary-mail-forward from C-c C-f to cf
- Remove E gnus-article-read-summary-keys which is not much useful