### PR TITLE
eglot: update binding

### DIFF
--- a/modes/eglot/evil-collection-eglot.el
+++ b/modes/eglot/evil-collection-eglot.el
@@ -37,7 +37,7 @@
   (evil-collection-define-key 'normal 'eglot-mode-map
     "gd" 'xref-find-definitions
     (kbd "C-t") 'xref-pop-marker-stack
-    "K" 'eglot-help-at-point))
+    "K" 'eldoc-doc-buffer))
 
 (provide 'evil-collection-eglot)
 ;;; evil-collection-eglot.el ends here


### PR DESCRIPTION
eglot-help-at-point has been removed since: https://github.com/joaotavora/eglot/commit/a044dec7f94d0d21bd65cf8a04f09cc63324db18