### PR TITLE
gnus: add topic commands

### DIFF
--- a/modes/gnus/evil-collection-gnus.el
+++ b/modes/gnus/evil-collection-gnus.el
@@ -42,6 +42,12 @@
   "Set up `evil' bindings for `gnus'."
   (evil-set-initial-state 'gnus-summary-mode 'normal)
   (evil-collection-define-key 'normal 'gnus-summary-mode-map
+    ;; quit
+    "Q"         'gnus-summary-exit-no-update
+    "q"         'gnus-summary-exit
+    "ZQ"        'gnus-summary-exit-no-update
+    "ZZ"        'gnus-summary-exit
+
     ;; motion
     (kbd "<tab>") 'gnus-summary-widget-forward
     (kbd "<backtab>") 'gnus-summary-widget-backward
@@ -49,140 +55,162 @@
     (kbd "S-SPC") 'gnus-summary-prev-page
     (kbd "SPC") 'gnus-summary-next-page
     (kbd "RET") 'gnus-summary-scroll-up
-    "]]" 'gnus-summary-next-unread-article
-    "[[" 'gnus-summary-prev-unread-article
+    "gk"        'gnus-summary-prev-unread-article
+    "gj"        'gnus-summary-next-unread-article
+    "[["        'gnus-summary-prev-unread-article
+    "]]"        'gnus-summary-next-unread-article
+    "{"         'gnus-summary-prev-thread
+    "}"         'gnus-summary-next-thread
     (kbd "C-j") 'gnus-summary-next-article
     (kbd "C-k") 'gnus-summary-prev-article
 
-
     ;; Marking
-    "m" 'gnus-summary-mark-as-processable
-    "M" 'gnus-summary-put-mark-as-read
-    "u" 'gnus-summary-clear-mark-forward
-    "U" 'gnus-summary-clear-mark-backward
+    "m"         'gnus-summary-mark-as-processable
+    "M"         'gnus-uu-mark-buffer
+    "u"         'gnus-summary-unmark-as-processable
+    "U"         'gnus-summary-unmark-all-processable
+    "%"         'gnus-uu-mark-by-regexp
 
-    "!" 'gnus-summary-execute-command
-    "|" 'gnus-summary-pipe-output
+    ;; Composing
+    "C"         'gnus-summary-mail-other-window
+    "cc"        'gnus-summary-mail-other-window
+    "ci"        'gnus-summary-news-other-window
+    "f"         'gnus-summary-followup
+    "F"         'gnus-summary-followup-with-original
+    "cf"        'gnus-summary-followup
+    "cF"        'gnus-summary-followup-with-original
 
-    "gu" 'gnus-summary-first-unread-article
-    "gU" 'gnus-summary-best-unread-article
+    ;; Reply
+    "r"         'gnus-summary-reply
+    "R"         'gnus-summary-reply-with-original
+    "cr"        'gnus-summary-reply
+    "cR"        'gnus-summary-reply-with-original
+    "cw"        'gnus-summary-very-wide-reply
+    "cW"        'gnus-summary-very-wide-reply-with-original
+    (kbd "C-c C-f") 'gnus-summary-mail-forward
 
-    "^" 'gnus-summary-refer-parent-article
+    ;; Actions, like mu4e
+    ;; Keep the following two bindings consistent with group's
+    "."         'gnus-summary-first-unread-article
+    ","         'gnus-summary-best-unread-article
+    "!"         'gnus-summary-mark-as-read-forward
+    "="         'gnus-summary-tick-article-forward
+    "J"         'gnus-summary-goto-article
+    "gr"        'gnus-summary-rescan-group
+    "e"         'gnus-summary-edit-article
+    "E"         'gnus-summary-mark-as-expirable
+    "zz"        'gnus-recenter
+    "z/"        'gnus-summary-limit-map
+    "zt"        'gnus-summary-toggle-header
+    "x"         'gnus-summary-limit-to-unread
+
+    ;; Finding the parent
+    "^"         'gnus-summary-refer-parent-article
     (kbd "M-^") 'gnus-summary-refer-article
 
-    "zz" 'gnus-recenter
-    "z/" 'gnus-summary-limit-map
-    "zd" 'gnus-summary-mark-as-dormant
-    "zt" 'gnus-summary-toggle-header
-    "x" 'gnus-summary-limit-to-unread
+    ;; Sorting
+    "oa"        'gnus-summary-sort-by-author
+    "oc"        'gnus-summary-sort-by-chars
+    "od"        'gnus-summary-sort-by-date
+    "oi"        'gnus-summary-sort-by-score
+    "ol"        'gnus-summary-sort-by-lines
+    "omd"       'gnus-summary-sort-by-most-recent-date
+    "omm"       'gnus-summary-sort-by-marks
+    "omn"       'gnus-summary-sort-by-most-recent-number
+    "on"        'gnus-summary-sort-by-number
+    "oo"        'gnus-summary-sort-by-original
+    "or"        'gnus-summary-sort-by-random
+    "os"        'gnus-summary-sort-by-subject
+    "ot"        'gnus-summary-sort-by-recipient
 
-    "J" 'gnus-summary-goto-article
+    ;; Threads commands
+    "Tk"        'gnus-summary-kill-thread
+    "Tl"        'gnus-summary-lower-thread
+    "Ti"        'gnus-summary-raise-thread
+    "Tm"        'gnus-uu-mark-thread        ;; was T #
+    "Tu"        'gnus-uu-unmark-thread      ;; was T M-#
+    "TT"        'gnus-summary-toggle-threads
+    "Ts"        'gnus-summary-show-thread
+    "Th"        'gnus-summary-hide-thread
+    ;; show/hide can be mapped to zo/zc
+    "zo"        'gnus-summary-show-thread
+    "zc"        'gnus-summary-hide-thread
+    "TS"        'gnus-summary-show-all-threads
+    "TH"        'gnus-summary-hide-all-threads
+    "Tt"        'gnus-summary-rethread-current
+    "T^"        'gnus-summary-reparent-thread
+    (kbd "T M-^") 'gnus-summary-reparent-children
+    "Tn"        'gnus-summary-next-thread
+    "Tp"        'gnus-summary-prev-thread
+    "Td"        'gnus-summary-down-thread   ;;          descend
+    "Ta"        'gnus-summary-up-thread     ;; was T u, ascend also makes sense
+    "To"        'gnus-summary-top-thread
 
-    "r" 'gnus-summary-reply
-    "R" 'gnus-summary-reply-with-original
-    ;; TODO: Should it be very-wide?
-    ;; "r" 'gnus-summary-very-wide-reply
-    ;; "R" 'gnus-summary-very-wide-reply-with-original
+    ;; Saving
+    "Oo"        'gnus-summary-save-article
+    "Om"        'gnus-summary-save-article-mail
+    "Or"        'gnus-summary-save-article-rmail
+    "Of"        'gnus-summary-save-article-file
+    "OF"        'gnus-summary-write-article-file
+    "Ob"        'gnus-summary-save-article-body-file
+    "Oh"        'gnus-summary-save-article-folder
+    "Ov"        'gnus-summary-save-article-vm
+    "Op"        'gnus-summary-pipe-output
+    "|"         'gnus-summary-pipe-output
+    "OP"        'gnus-summary-muttprint
 
-    "gO" 'gnus-summary-save-map
-    "gS" 'gnus-summary-send-map
-    "gT" 'gnus-summary-thread-map
-    "gV" 'gnus-summary-score-map
-    "gW" 'gnus-summary-wash-map
-    "X" 'gnus-uu-extract-map
-    "gY" 'gnus-summary-buffer-map
-    "gZ" 'gnus-summary-exit-map
+    ;; Decoding with marked articles
+    "Xu"        'gnus-uu-decode-uu
+    "XU"        'gnus-uu-decode-uu-and-save
+    "Xvu"       'gnus-uu-decode-uu-view
+    "XvU"       'gnus-uu-decode-uu-and-save-view
+    ;; Shell archives
+    "Xs"        'gnus-uu-decode-unshar
+    "XS"        'gnus-uu-decode-unshar-and-save
+    "Xvs"       'gnus-uu-decode-unshar-view
+    "XvS"       'gnus-uu-decode-unshar-and-save-view
+    ;; PostScript files
+    "Xp"        'gnus-uu-decode-postscript
+    "XP"        'gnus-uu-decode-postscript-and-save
+    "Xvp"       'gnus-uu-decode-postscript-view
+    "XvP"       'gnus-uu-decode-postscript-and-save-view
+    ;; Other files
+    "Xo"        'gnus-uu-decode-save
+    "Xb"        'gnus-uu-decode-binhex
+    "XY"        'gnus-uu-decode-yenc
 
-    ;; filter
-    "s" 'gnus-summary-isearch-article
+    ;; Mail group commands
+    "Be"        'gnus-summary-expire-articles
+    "BE"        'gnus-summary-expire-articles-now   ;; was B C-M-e
+    "Bd"        'gnus-summary-delete-article        ;; was B DEL
+    "Bm"        'gnus-summary-move-article
+    "Bc"        'gnus-summary-copy-article
+    "Bb"        'gnus-summary-crosspost-article     ;; was B B
+    "Bi"        'gnus-summary-import-article
+    "BI"        'gnus-summary-create-article
+    "Br"        'gnus-summary-respool-article
+    "Bw"        'gnus-summary-edit-article
+    "Bq"        'gnus-summary-respool-query
+    "Bt"        'gnus-summary-respool-trace
+    "Bp"        'gnus-summary-article-posted-p
 
-    ;; search
+    ;; Searching
     (kbd "M-s") 'gnus-summary-search-article-forward
     (kbd "M-r") 'gnus-summary-search-article-backward
     (kbd "M-S") 'gnus-summary-repeat-search-article-forward
     (kbd "M-R") 'gnus-summary-repeat-search-article-backward
+    "&"         'gnus-summary-execute-command
+    (kbd "M-&") 'gnus-summary-universal-argument
 
-    ;; sort
-    "oa" 'gnus-summary-sort-by-author
-    "oc" 'gnus-summary-sort-by-chars
-    "od" 'gnus-summary-sort-by-date
-    "oi" 'gnus-summary-sort-by-score
-    "ol" 'gnus-summary-sort-by-lines
-    "omd" 'gnus-summary-sort-by-most-recent-date
-    "omm" 'gnus-summary-sort-by-marks
-    "omn" 'gnus-summary-sort-by-most-recent-number
-    "on" 'gnus-summary-sort-by-number
-    "oo" 'gnus-summary-sort-by-original
-    "or" 'gnus-summary-sort-by-random
-    "os" 'gnus-summary-sort-by-subject
-    "ot" 'gnus-summary-sort-by-recipient
-
-    [mouse-2] 'gnus-mouse-pick-article
+    [mouse-2]   'gnus-mouse-pick-article
     [follow-link] 'mouse-face
 
-    "gr" 'gnus-summary-rescan-group
-
     ;; Rest of the bindings "as is".
-    "d" 'gnus-summary-mark-as-read-forward
-    "D" 'gnus-summary-mark-as-read-backward
-    "E" 'gnus-summary-mark-as-expirable
-    (kbd "M-u") 'gnus-summary-clear-mark-forward
-    (kbd "M-U") 'gnus-summary-clear-mark-backward
-    (kbd "M-C-k") 'gnus-summary-kill-thread
-    (kbd "M-C-l") 'gnus-summary-lower-thread
-    "e" 'gnus-summary-edit-article
-    (kbd "M-C-t") 'gnus-summary-toggle-threads
-    "zs" 'gnus-summary-show-thread
-    "zh" 'gnus-summary-hide-thread
-    (kbd "M-C-f") 'gnus-summary-next-thread
-    (kbd "M-C-b") 'gnus-summary-prev-thread
-    (kbd "<M-down>") 'gnus-summary-next-thread
-    (kbd "<M-up>") 'gnus-summary-prev-thread
-    (kbd "M-C-u") 'gnus-summary-up-thread
-    (kbd "M-C-d") 'gnus-summary-down-thread
-    "c" 'gnus-summary-catchup-and-exit
-    (kbd "C-t") 'toggle-truncate-lines
-    (kbd "C-c M-C-s") 'gnus-summary-limit-include-expunged
-    "=" 'gnus-summary-expand-window
-    (kbd "C-x C-s") 'gnus-summary-reselect-current-group
-    (kbd "C-c C-r") 'gnus-summary-caesar-message
-    "f" 'gnus-summary-followup
-    "F" 'gnus-summary-followup-with-original
-    "C" 'gnus-summary-cancel-article
-    (kbd "C-c C-f") 'gnus-summary-mail-forward
-    ".s" 'gnus-summary-save-article     ; Like notmuch?
-    (kbd "C-o") 'gnus-summary-save-article-mail
-    (kbd "M-k") 'gnus-summary-edit-local-kill
-    (kbd "M-K") 'gnus-summary-edit-global-kill
-    ;; "V" 'gnus-version
-    (kbd "C-c C-d") 'gnus-summary-describe-group
-    "zm" 'gnus-summary-mail-other-window
-    "a" 'gnus-summary-post-news
-    ;; "g" 'gnus-summary-show-article
-    "gG" 'gnus-summary-goto-last-article
-    (kbd "C-c C-v C-v") 'gnus-uu-decode-uu-view
-    ;; "\C-d" 'gnus-summary-enter-digest-group
-    ;; "\M-\C-d" 'gnus-summary-read-document
-    (kbd "M-C-e") 'gnus-summary-edit-parameters
-    (kbd "M-C-a") 'gnus-summary-customize-parameters
-    (kbd "C-c C-b") 'gnus-bug
-    "*" 'gnus-cache-enter-article
+    "*"         'gnus-cache-enter-article
     (kbd "M-*") 'gnus-cache-remove-article
-    (kbd "M-&") 'gnus-summary-universal-argument
     (kbd "M-i") 'gnus-symbolic-argument
-    "I" 'gnus-summary-increase-score
-    "L" 'gnus-summary-lower-score
-    ;; "h" 'gnus-summary-select-article-buffer
-
-    "K" 'gnus-info-find-node
-    "zv" 'gnus-article-view-part
-    (kbd "M-t") 'gnus-summary-toggle-display-buttonized
-
-    ;; quit
-    "Q" 'gnus-summary-exit-no-update
-    "q" 'gnus-summary-exit
-    "ZQ" 'gnus-summary-exit-no-update
-    "ZZ" 'gnus-summary-exit)
+    "I"         'gnus-summary-increase-score
+    "L"         'gnus-summary-lower-score)
 
   (evil-set-initial-state 'gnus-article-mode 'normal)
   (evil-collection-define-key 'motion 'gnus-article-mode-map
@@ -209,11 +237,57 @@
     ;; Composing
     "C"         'gnus-article-mail
     "cc"        'gnus-article-mail
-    "cf"        'gnus-summary-mail-forward
+    "cr"        'gnus-summary-reply
+    "cR"        'gnus-summary-reply-with-original
+    "cf"        'gnus-summary-followup
+    "cF"        'gnus-summary-followup-with-original
+    "cw"        'gnus-summary-very-wide-reply
+    "cW"        'gnus-article-wide-reply-with-original
+    (kbd "C-c C-f") 'gnus-summary-mail-forward
+
+    ;; Washing
+    ;;
+    ;; List of unbound commands:
+    ;; - `gnus-article-remove-cr'
+    ;; - `gnus-article-de-quoted-unreadable'
+    ;; - `gnus-article-unsplit-urls'
+    ;; - `gnus-article-wash-html'
+    ;; - `gnus-article-strip-leading-blank-lines'
+    ;; - `gnus-article-strip-multiple-blank-lines'
+    ;; - `gnus-article-remove-trailing-blank-lines'
+    ;; - `gnus-article-strip-blank-lines'
+    ;; - `gnus-article-strip-all-blank-lines'
+    ;; - `gnus-article-strip-leading-space'
+    ;; - `gnus-article-strip-trailing-space'
+    "zwl"       'gnus-summary-stop-page-breaking
+    "zwr"       'gnus-summary-caesar-message
+    "zwm"       'gnus-summary-morse-message
+    "zwi"       'gnus-summary-idna-message
+    "zwt"       'gnus-summary-toggle-header
+    "zwv"       'gnus-summary-verbose-headers
+    "zwo"       'gnus-article-treat-overstrike
+    "zwd"       'gnus-article-treat-smartquotes
+    "zwu"       'gnus-article-treat-non-ascii               ;; was W U
+    "zwyf"      'gnus-article-outlook-deuglify-article
+    "zwyu"      'gnus-article-outlook-unwrap-lines
+    "zwya"      'gnus-article-outlook-repair-attribution
+    "zwyc"      'gnus-article-outlook-rearrange-citation
+    "zww"       'gnus-article-fill-cited-article
+    "zwq"       'gnus-article-fill-long-lines               ;; was W Q
+    "zwc"       'gnus-article-capitalize-sentences          ;; was W C
+    "zw6"       'gnus-article-de-base64-unreadable
+    "zwz"       'gnus-article-decode-HZ                     ;; was W Z
+    "zwa"       'gnus-article-treat-ansi-sequences          ;; was W A
+    "zwb"       'gnus-article-add-buttons
+    "zwB"       'gnus-article-add-buttons-to-head
+    "zwp"       'gnus-article-verify-x-pgp-sig
+    "zws"       'gnus-summary-force-verify-and-decrypt
 
     ;; Actions
     (kbd "C-]") 'gnus-article-refer-article
-    "s"         'gnus-article-show-summary)
+    "s"         'gnus-article-show-summary
+    "gr"        'gnus-summary-show-article
+    "gX"        'gnus-summary-browse-url)
 
   (evil-set-initial-state 'gnus-group-mode 'normal)
   (evil-collection-define-key 'normal 'gnus-group-mode-map
@@ -223,8 +297,6 @@
     "ZQ"        'gnus-group-quit
 
     ;; Movement
-    "k"         'gnus-group-prev-group
-    "j"         'gnus-group-next-group
     "[["        'gnus-group-prev-unread-group
     "]]"        'gnus-group-next-unread-group
     "gk"        'gnus-group-prev-unread-group
@@ -237,6 +309,7 @@
 
     ;; Actions
     "."         'gnus-group-first-unread-group
+    ","         'gnus-group-best-unread-group
     "A"         'gnus-activate-all-groups
     "B"         'gnus-group-browse-foreign-server
     "E"         'gnus-group-edit-group
@@ -244,6 +317,7 @@
     "J"         'gnus-group-jump-to-group
     "R"         'gnus-group-rename-group
     "X"         'gnus-group-expunge-group
+    "Z"         'gnus-group-compact-group
     (kbd "RET") 'gnus-group-select-group
     (kbd "SPC") 'gnus-group-read-group
     "gr"        'gnus-group-get-new-news-this-group
@@ -254,6 +328,7 @@
     "gC"        'gnus-group-catchup-current-all
     "ge"        'gnus-group-expire-articles
     "gE"        'gnus-group-expire-all-groups
+    "gl"        'gnus-group-set-current-level
 
     ;; Deleting & Pasting
     "dd"        'gnus-group-kill-group
@@ -272,6 +347,7 @@
     ;; Searching
     "s"         'gnus-group-apropos
     "S"         'gnus-group-description-apropos
+    (kbd "M-s") 'gnus-group-read-ephemeral-search-group
 
     ;; Sorting
     "oa"        'gnus-group-sort-groups-by-alphabet
@@ -298,6 +374,25 @@
     "Ls"        'gnus-group-list-groups
     "Lu"        'gnus-group-list-all-groups
     "Lz"        'gnus-group-list-zombies
+
+    ;; Topic commands
+    ;; `gnus-topic-move-group' can be done through dd then p
+    "Tn"        'gnus-topic-create-topic
+    "Tj"        'gnus-topic-jump-to-topic
+    "Tr"        'gnus-topic-rename
+    "Td"        'gnus-topic-delete
+    "zc"        'gnus-topic-hide-topic
+    "zo"        'gnus-topic-show-topic
+
+    ;; Topic sorting
+    "Toa"       'gnus-topic-sort-groups-by-alphabet
+    "Tou"       'gnus-topic-sort-groups-by-unread
+    "Tol"       'gnus-topic-sort-groups-by-level
+    "Tov"       'gnus-topic-sort-groups-by-score
+    "Tor"       'gnus-topic-sort-groups-by-rank
+    "Tom"       'gnus-topic-sort-groups-by-method
+    "Toe"       'gnus-group-sort-groups-by-server
+    "Tos"       'gnus-group-sort-groups
 
     "^"         'gnus-group-enter-server-mode
 


### PR DESCRIPTION
The `j`/`k` bindings are removed to make `gnus-group-yank-group` work when all topics are empty.