### PR TITLE
Fix #386: Remove broken (interactive) specs

### DIFF
--- a/modes/hungry-delete/evil-collection-hungry-delete.el
+++ b/modes/hungry-delete/evil-collection-hungry-delete.el
@@ -35,7 +35,6 @@
 (defun evil-collection-hungry-delete (f &rest args)
   "Wrapper function to run `hungry-delete-backward' if
 `hungry-delete-mode' is on."
-  (interactive)
   (if (and (bound-and-true-p hungry-delete-mode)
            (fboundp 'hungry-delete-backward))
       (hungry-delete-backward 1)
@@ -44,7 +43,6 @@
 (defun evil-collection-hungry-delete-for-join (f &rest args)
   "Wrapper function to run `hungry-delete-backward' if
 `hungry-delete-mode' is on."
-  (interactive)
   (if (and (bound-and-true-p hungry-delete-mode)
            (fboundp 'hungry-delete-backward))
       (hungry-delete-backward 1)


### PR DESCRIPTION
Remove `(interactive)` specs of `evil-collection-hungry-delete` and `evil-collection-hungry-delete-for-join` as they break `evil-collection-hungry-delete` and `evil-collection-hungry-delete-for-join` when `hungry-delete-mode` is bound but not enabled.
This fixes issue #386.