### PR TITLE
indent: add evil style bindings for `indent-rigidly'

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -186,6 +186,7 @@ through removing their entry from `evil-collection-mode-list'."
     image+
     imenu
     imenu-list
+    (indent "indent")
     indium
     info
     ivy

--- a/modes/indent/evil-collection-indent.el
+++ b/modes/indent/evil-collection-indent.el
@@ -1,0 +1,48 @@
+;;; evil-collection-indent.el --- Evil bindings for indentation -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020 Zhiwei Chen
+
+;; Author: Zhiwei Chen <condy0919@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: evil, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil bindings for indentation.
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'evil-collection)
+
+(defconst evil-collection-indent-maps '(indent-rigidly-map))
+
+;;;###autoload
+(defun evil-collection-indent-setup ()
+  "Set up `evil' bindings for autoloaded files."
+  (evil-collection-define-key nil 'indent-rigidly-map
+    "h" 'indent-rigidly-left
+    "l" 'indent-rigidly-right
+    "H" 'indent-rigidly-left-to-tab-stop
+    "L" 'indent-rigidly-right-to-tab-stop))
+
+
+(provide 'evil-collection-indent)
+;;; evil-collection-indent.el ends here


### PR DESCRIPTION
`indent.el` has no `(provides 'indent)` since it's autoloaded.