### PR TITLE
compile: Apply bindings to compilation-minor-mode-map

### DIFF
--- a/modes/compile/evil-collection-compile.el
+++ b/modes/compile/evil-collection-compile.el
@@ -40,6 +40,9 @@
 
   (dolist (keymap evil-collection-compile-maps)
 
+    (evil-collection-define-key nil keymap
+      "g" nil)
+
     (evil-collection-define-key 'normal keymap
       (kbd "RET") 'compile-goto-error
 

--- a/modes/compile/evil-collection-compile.el
+++ b/modes/compile/evil-collection-compile.el
@@ -30,7 +30,8 @@
 (require 'evil-collection)
 (require 'compile)
 
-(defconst evil-collection-compile-maps '(compilation-mode-map compilation-minor-mode-map))
+(defconst evil-collection-compile-maps '(compilation-mode-map
+                                         compilation-minor-mode-map))
 
 ;;;###autoload
 (defun evil-collection-compile-setup ()
@@ -40,12 +41,6 @@
   (dolist (keymap evil-collection-compile-maps)
 
     (evil-collection-define-key 'normal keymap
-      "g?" 'describe-mode
-      "?" evil-collection-evil-search-backward
-      "gg" 'evil-goto-first-line
-      "0" 'evil-digit-argument-or-evil-beginning-of-line
-      [mouse-2] 'compile-goto-error
-      [follow-link] 'mouse-face
       (kbd "RET") 'compile-goto-error
 
       "go" 'compilation-display-error

--- a/modes/compile/evil-collection-compile.el
+++ b/modes/compile/evil-collection-compile.el
@@ -30,32 +30,34 @@
 (require 'evil-collection)
 (require 'compile)
 
-(defconst evil-collection-compile-maps '(compilation-mode-map))
+(defconst evil-collection-compile-maps '(compilation-mode-map compilation-minor-mode-map))
 
 ;;;###autoload
 (defun evil-collection-compile-setup ()
   "Set up `evil' bindings for `compile'."
   (evil-set-initial-state 'compilation-mode 'normal)
 
-  (evil-collection-define-key 'normal 'compilation-mode-map
-    "g?" 'describe-mode
-    "?" evil-collection-evil-search-backward
-    "gg" 'evil-goto-first-line
-    "0" 'evil-digit-argument-or-evil-beginning-of-line
-    [mouse-2] 'compile-goto-error
-    [follow-link] 'mouse-face
-    (kbd "RET") 'compile-goto-error
+  (dolist (keymap evil-collection-compile-maps)
 
-    "go" 'compilation-display-error
-    (kbd "S-<return>") 'compilation-display-error
+    (evil-collection-define-key 'normal keymap
+      "g?" 'describe-mode
+      "?" evil-collection-evil-search-backward
+      "gg" 'evil-goto-first-line
+      "0" 'evil-digit-argument-or-evil-beginning-of-line
+      [mouse-2] 'compile-goto-error
+      [follow-link] 'mouse-face
+      (kbd "RET") 'compile-goto-error
 
-    "gj" 'compilation-next-error
-    "gk" 'compilation-previous-error
-    (kbd "C-j") 'compilation-next-error
-    (kbd "C-k") 'compilation-previous-error
-    "[[" 'compilation-previous-file
-    "]]" 'compilation-next-file
-    "gr" 'recompile))
+      "go" 'compilation-display-error
+      (kbd "S-<return>") 'compilation-display-error
+
+      "gj" 'compilation-next-error
+      "gk" 'compilation-previous-error
+      (kbd "C-j") 'compilation-next-error
+      (kbd "C-k") 'compilation-previous-error
+      "[[" 'compilation-previous-file
+      "]]" 'compilation-next-file
+      "gr" 'recompile)))
 
 (provide 'evil-collection-compile)
 ;;; evil-collection-compile.el ends here

--- a/modes/simple/evil-collection-simple.el
+++ b/modes/simple/evil-collection-simple.el
@@ -39,14 +39,11 @@
   "Set up `evil' bindings for `simple'."
 
   (evil-collection-define-key nil 'special-mode-map
-    "g" nil)
-
-  (evil-collection-define-key '(normal visual) 'special-mode-map
-    "q" 'quit-window
-    " " 'scroll-up-command
-    "g?" 'describe-mode
-    "h" 'evil-backward-char
-    "gr" 'revert-buffer))
+    "g" nil
+    "gr" 'revert-buffer
+    "h" nil
+    "?" nil
+    "0" nil))
 
 (provide 'evil-collection-simple)
 ;;; evil-collection-simple.el ends here


### PR DESCRIPTION
Before this change compilation bindings didn't work in grep-mode which inherits
compilation-minor-mode-map