### PR TITLE
Preserve emacs bindings 

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -365,6 +365,18 @@ to filter keys on the basis of `evil-collection-key-whitelist' and
                                 err))))))
              (add-hook 'after-load-functions fun t))))))
 
+(cl-defun evil-collection-move-bindings-to-emacs-state (map-sym &rest keys)
+  "Move KEYS in MAP-SYM to the `emacs' state."
+  (let* ((keymap (symbol-value map-sym))
+         (bindings (mapcan (lambda (key)
+                             (list key (lookup-key keymap key)))
+                           keys))
+         (unbindings (mapcan (lambda (key)
+                               (list key nil))
+                             keys)))
+    (apply #'evil-collection-define-key nil map-sym unbindings)
+    (apply #'evil-collection-define-key 'emacs map-sym bindings)))
+
 (defun evil-collection-inhibit-insert-state (map-sym)
   "Unmap insertion keys from normal state.
 This is particularly useful for read-only modes."

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -69,26 +69,19 @@ be set through custom or before evil-collection loads."
 ;;;###autoload
 (defun evil-collection-company-setup ()
   "Set up `evil' bindings for `company'."
-  (evil-collection-define-key nil 'company-active-map
-    (kbd "C-n") 'company-select-next-or-abort
-    (kbd "C-p") 'company-select-previous-or-abort
-    (kbd "C-j") 'company-select-next-or-abort
-    (kbd "C-k") 'company-select-previous-or-abort
-    (kbd "M-j") 'company-select-next
-    (kbd "M-k") 'company-select-previous)
+  (evil-collection-move-bindings-to-emacs-state 'company-active-map
+    (kbd "C-n") (kbd "C-p") (kbd "C-j") (kbd "C-k") (kbd "M-j") (kbd "M-k"))
 
   (when evil-want-C-u-scroll
-    (evil-collection-define-key nil 'company-active-map (kbd "C-u") 'company-previous-page))
+    (evil-collection-move-bindings-to-emacs-state 'company-active-map
+      (kbd "C-u")))
 
   (when evil-want-C-d-scroll
-    (evil-collection-define-key nil 'company-active-map (kbd "C-d") 'company-next-page))
+    (evil-collection-move-bindings-to-emacs-state 'company-active-map
+      (kbd "C-d")))
 
-  (evil-collection-define-key nil 'company-search-map
-    (kbd "C-j") 'company-select-next-or-abort
-    (kbd "C-k") 'company-select-previous-or-abort
-    (kbd "M-j") 'company-select-next
-    (kbd "M-k") 'company-select-previous
-    (kbd "<escape>") 'company-search-abort)
+  (evil-collection-move-bindings-to-emacs-state 'company-search-map
+    (kbd "C-j") (kbd "C-k") (kbd "M-j") (kbd "M-k") (kbd "<escape>"))
 
   ;; Sets up YCMD like behavior.
   (when evil-collection-company-use-tng

--- a/modes/compile/evil-collection-compile.el
+++ b/modes/compile/evil-collection-compile.el
@@ -40,8 +40,8 @@
 
   (dolist (keymap evil-collection-compile-maps)
 
-    (evil-collection-define-key nil keymap
-      "g" nil)
+    (evil-collection-move-bindings-to-emacs-state keymap
+      "g")
 
     (evil-collection-define-key 'normal keymap
       (kbd "RET") 'compile-goto-error

--- a/modes/edebug/evil-collection-edebug.el
+++ b/modes/edebug/evil-collection-edebug.el
@@ -42,9 +42,8 @@
 
   (add-hook 'edebug-mode-hook #'evil-normalize-keymaps)
 
-  (evil-collection-define-key nil 'edebug-mode-map
-    "g" nil
-    "G" nil)
+  (evil-collection-move-bindings-to-emacs-state 'edebug-mode-map
+    "g" "G")
 
   ;; FIXME: Seems like other minor modes will readily clash with `edebug'.
   ;; `lispyville' and `edebug' 's' key?

--- a/modes/ivy/evil-collection-ivy.el
+++ b/modes/ivy/evil-collection-ivy.el
@@ -37,8 +37,10 @@
 ;;;###autoload
 (defun evil-collection-ivy-setup ()
   "Set up `evil' bindings for `ivy-mode'."
-  (evil-collection-define-key nil 'ivy-mode-map
-    (kbd "<escape>") 'minibuffer-keyboard-quit)
+
+  (evil-collection-move-bindings-to-emacs-state 'ivy-mode-map
+    (kbd "<escape>"))
+
   (evil-collection-define-key 'normal 'ivy-occur-mode-map
     [mouse-1] 'ivy-occur-click
     (kbd "RET") 'ivy-occur-press-and-switch

--- a/modes/magit-todos/evil-collection-magit-todos.el
+++ b/modes/magit-todos/evil-collection-magit-todos.el
@@ -48,11 +48,11 @@
 (defun evil-collection-magit-todos-setup ()
   "Set up `evil' bindings for `magit-todos'."
   ;; magit-todos binds jT which prevents evil users from stepping into the section
-  (evil-collection-define-key nil 'magit-todos-section-map
-    "j" nil)
+  (evil-collection-move-bindings-to-emacs-state 'magit-todos-section-map
+    "j")
 
-  (evil-collection-define-key nil 'magit-todos-item-section-map
-    "j" nil)
+  (evil-collection-move-bindings-to-emacs-state 'magit-todos-item-section-map
+    "j")
 
   ;; No need to tell me that jT isn't bound
   (advice-add 'magit-todos-mode :around 'evil-collection-magit-todos-supress-warning)

--- a/modes/popup/evil-collection-popup.el
+++ b/modes/popup/evil-collection-popup.el
@@ -36,9 +36,8 @@
 (defun evil-collection-popup-setup ()
   "Set up `evil' bindings for `popup'."
   (defvar popup-menu-keymap)
-  (evil-collection-define-key nil 'popup-menu-keymap
-    (kbd "C-j") 'popup-next
-    (kbd "C-k") 'popup-previous))
+  (evil-collection-move-bindings-to-emacs-state 'popup-menu-keymap
+    (kbd "C-j") (kbd "C-k")))
 
 (provide 'evil-collection-popup)
 ;;; evil-collection-popup.el ends here

--- a/modes/simple/evil-collection-simple.el
+++ b/modes/simple/evil-collection-simple.el
@@ -38,12 +38,11 @@
 (defun evil-collection-simple-setup ()
   "Set up `evil' bindings for `simple'."
   (evil-collection-set-readonly-bindings 'special-mode-map)
-  (evil-collection-define-key nil 'special-mode-map
-    "g" nil
-    "gr" 'revert-buffer
-    "h" nil
-    "?" nil
-    "0" nil))
+  (evil-collection-move-bindings-to-emacs-state 'special-mode-map
+    "g" "h" "?" "0"))
+
+  (evil-collection-define-key 'normal 'special-mode-map
+    "gr" 'revert-buffer)
 
 (provide 'evil-collection-simple)
 ;;; evil-collection-simple.el ends here

--- a/modes/tabulated-list/evil-collection-tabulated-list.el
+++ b/modes/tabulated-list/evil-collection-tabulated-list.el
@@ -37,9 +37,8 @@
 (defun evil-collection-tabulated-list-setup ()
   "Set up `evil' bindings for `tabulated-list'."
 
-  (evil-collection-define-key nil 'tabulated-list-mode-map
-    "n" nil
-    "p" nil)
+  (evil-collection-move-bindings-to-emacs-state 'tabulated-list-mode-map
+    "n" "p")
 
   (evil-set-initial-state 'tabulated-list-mode 'normal)
   (evil-collection-define-key 'normal 'tabulated-list-mode-map

--- a/modes/which-key/evil-collection-which-key.el
+++ b/modes/which-key/evil-collection-which-key.el
@@ -42,11 +42,8 @@
   "Set up `evil' bindings for `which-key'."
 
   ;; (evil-collection-define-key nil 'which-key-C-h-map "u" 'which-key-undo-key)
-  (evil-collection-define-key nil 'which-key-C-h-map
-    "q" 'which-key-abort
-    "j" 'which-key-show-next-page-cycle
-    "k" 'which-key-show-previous-page-cycle
-    "?" 'which-key-show-standard-help))
+(evil-collection-move-bindings-to-emacs-state 'which-key-C-h-map
+    "q" "j" "k" "?"))
 
 (provide 'evil-collection-which-key)
 ;;; evil-collection-which-key.el ends here


### PR DESCRIPTION
@Ambrevar This is my response to your request (https://github.com/emacs-evil/evil-collection/pull/392#issuecomment-714981635)

This change affects a lot of modes so it should be reviewed thoroughly and with care. It seems to work for me (emacs 27.1), but I wouldn't consider my testing to be thorough. Also a little bikeshedding might be in order (is translate what we're doing? did I name the function right?)

The gist of it is:

We unbind bindings so that the keypress will fall through that keymap and be caught by another keymap. For example, we often unmap "j" so it will fall through to an evil layer that will call a movement function instead of being caught by the current mode. However our current method of unmapping applies to the emacs state as well. Obviously we want a way to unmap "j" in every state except the emacs state.

To accomplish this I've introduced a function called `evil-collection-translate-key-to-state' which allows us to move any key binding from one state to another. This way instead of unbinding keys, we can simply move them to the emacs state.