### PR TITLE
Add shortdoc evil bindings

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -237,6 +237,7 @@ through removing their entry from `evil-collection-mode-list'."
     robe
     rtags
     ruby-mode
+    ,@(when (>= emacs-major-version 28) '(shortdoc))
     simple
     slime
     sly

--- a/modes/org-present/evil-collection-org-present.el
+++ b/modes/org-present/evil-collection-org-present.el
@@ -28,9 +28,9 @@
 
 ;;; Code:
 (require 'evil-collection)
-(require 'org-present nil t) 
+(require 'org-present nil t)
 
-(defvar org-present-mode-map) 
+(defvar org-present-mode-map)
 
 (defconst evil-collection-org-present-maps '(org-present-mode-map))
 
@@ -38,29 +38,29 @@
 (defun evil-collection-org-present-setup ()
   "Set up `evil' bindings for `org-present'."
   (evil-collection-define-key 'normal 'org-present-mode-map
-    "j" 'org-present-next 
-    "k" 'org-present-prev 
-    "gj" 'org-present-next 
-    "gk" 'org-present-prev 
-    "]]" 'org-present-next 
-    "[[" 'org-present-prev 
-    (kbd "SPC") 'org-present-next 
-    (kbd "S-SPC") 'org-present-prev 
-    (kbd "C-j") 'org-present-next 
-    (kbd "M-j") 'org-present-next 
-    (kbd "C-k") 'org-present-prev 
-    (kbd "M-k") 'org-present-prev 
+    "j" 'org-present-next
+    "k" 'org-present-prev
+    "gj" 'org-present-next
+    "gk" 'org-present-prev
+    "]]" 'org-present-next
+    "[[" 'org-present-prev
+    (kbd "SPC") 'org-present-next
+    (kbd "S-SPC") 'org-present-prev
+    (kbd "C-j") 'org-present-next
+    (kbd "M-j") 'org-present-next
+    (kbd "C-k") 'org-present-prev
+    (kbd "M-k") 'org-present-prev
     "zi" 'org-present-big
     "zo" 'org-present-small
     "+" 'org-present-big
-    "=" 'org-present-big 
-    "-" 'org-present-small 
-    "q" 'org-present-quit 
+    "=" 'org-present-big
+    "-" 'org-present-small
+    "q" 'org-present-quit
     "ZQ" 'org-present-quit
     "ZZ" 'org-present-quit
-    "r" 'org-present-read-only 
-    "w" 'org-present-read-write 
-    "gg" 'org-present-beginning 
+    "r" 'org-present-read-only
+    "w" 'org-present-read-write
+    "gg" 'org-present-beginning
     "G" 'org-present-end))
 
 (provide 'evil-collection-org-present)

--- a/modes/shortdoc/evil-collection-shortdoc.el
+++ b/modes/shortdoc/evil-collection-shortdoc.el
@@ -1,0 +1,47 @@
+;;; evil-collection-shortdoc.el --- Evil bindings for shortdoc -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020 Zhiwei Chen
+
+;; Author: Zhiwei Chen <condy0919@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; TODO: Update to emacs 28.1 when it's out
+;; Package-Requires: ((emacs "27.1"))
+;; Keywords: evil, lisp, help
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil bindings for shortdoc.
+
+;;; Code:
+(require 'evil-collection)
+(require 'shortdoc nil t)
+
+(defconst evil-collection-shortdoc-maps '(shortdoc-mode-map))
+
+;;;###autoload
+(defun evil-collection-shortdoc-setup ()
+  "Set up `evil' bindings for `shortdoc'."
+  (evil-set-initial-state 'shortdoc-mode 'normal)
+  (evil-collection-define-key 'normal 'shortdoc-mode-map
+    (kbd "C-k") 'shortdoc-previous
+    (kbd "C-j") 'shortdoc-next
+    "[[" 'shortdoc-previous-section
+    "]]" 'shortdoc-next-section))
+
+(provide 'evil-collection-shortdoc)
+;;; evil-collection-shortdoc.el ends here


### PR DESCRIPTION
`shortdoc` comes from Emacs 28 which has not been released yet so I temporaily
set `Package-Requires` to ``((emacs "27.1"))`` otherwise `package-lint` will
fail.

Additionally the trailing whitespaces in org-present mode are removed.
