### PR TITLE
prodigy: add more keybindings to prodigy-view-mode from prodigy-mode

### DIFF
--- a/modes/prodigy/evil-collection-prodigy.el
+++ b/modes/prodigy/evil-collection-prodigy.el
@@ -74,6 +74,12 @@
     (kbd "Y") 'prodigy-copy-cmd)
 
   (evil-collection-define-key 'normal 'prodigy-view-mode-map
+    "s" 'prodigy-start
+    "S" 'prodigy-stop
+    "gr" 'prodigy-restart
+    "r" 'prodigy-restart
+    "c" 'prodigy-view-clear-buffer
+    "c-l" 'prodigy-view-clear-buffer
     "x" 'prodigy-view-clear-buffer))
 
 (provide 'evil-collection-prodigy)


### PR DESCRIPTION
Hey there, I added some keybindings that were missing on prodigy-view-mode compared to prodigy-mode. This mode is different from prodigy-mode but has similar actions.