### PR TITLE
Occur mode C-j and C-k

### DIFF
--- a/modes/occur/evil-collection-occur.el
+++ b/modes/occur/evil-collection-occur.el
@@ -54,10 +54,10 @@
     (kbd "M-<return>") 'occur-mode-display-occurrence
     "go" 'occur-mode-goto-occurrence-other-window
 
-    "gj" 'occur-next
-    "gk" 'occur-prev
-    (kbd "C-j") 'occur-next
-    (kbd "C-k") 'occur-prev
+    "gj" 'next-error-no-select
+    "gk" 'previous-error-no-select
+    (kbd "C-j") 'next-error-no-select
+    (kbd "C-k") 'previous-error-no-select
     "r" 'occur-rename-buffer
     "c" 'clone-buffer
     (kbd "C-c C-f") 'next-error-follow-minor-mode)


### PR DESCRIPTION
This fixes the C-j and C-k behavior discussed in #408 .

I went with the `-no-select` versions of `next-error` and `previous-error` since these retain focus in the occur buffer while navigating the results with preview (as opposed to visiting the locations and moving focus to the original window).
