### PR TITLE
Add basic support for dictionary-mode

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,6 +7,7 @@
  (depends-on "evil")
  (depends-on "f")
  (depends-on "ert-runner")
+ (depends-on "dictionary")
  (depends-on "package-lint")
  (depends-on "annalist")
  (depends-on "magit"))

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -140,6 +140,7 @@ through removing their entry from `evil-collection-mode-list'."
     deadgrep
     debbugs
     debug
+    dictionary
     diff-mode
     dired
     dired-sidebar

--- a/modes/dictionary/evil-collection-dictionary.el
+++ b/modes/dictionary/evil-collection-dictionary.el
@@ -1,0 +1,51 @@
+;;; evil-collection-dictionary.el --- Evil bindings for dictionary-mode -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen
+
+;; Author: Sid Kasivajhula <sid@countvajhula.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: evil, dictionary, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil bindings for `dictionary'.
+
+;;; Code:
+(require 'evil-collection)
+(require 'dictionary)
+
+(defconst evil-collection-dictionary-maps '(dictionary-mode-map))
+
+;;;###autoload
+(defun evil-collection-dictionary-setup ()
+  "Set up `evil' bindings for `dictionary'."
+  (evil-set-initial-state 'dictionary-mode 'normal)
+  (evil-collection-set-readonly-bindings 'dictionary-mode-map)
+  (evil-collection-define-key 'normal 'dictionary-mode-map
+    ;; motion
+    (kbd "l") 'evil-forward-char ; otherwise bound to `dictionary-previous`
+    (kbd "h") 'evil-backward-char ; otherwise bound to `dictionary-help`
+    ;; mouse
+    [mouse-1] 'link-selected
+    ;; misc
+    (kbd "?") 'dictionary-help ; normally under `h` which is rebound here
+    (kbd "C-o") 'dictionary-previous) ; normally under `l` which is rebound here
+
+(provide 'evil-collection-dictionary)
+;;; evil-collection-dictionary.el ends here

--- a/modes/dictionary/evil-collection-dictionary.el
+++ b/modes/dictionary/evil-collection-dictionary.el
@@ -44,8 +44,8 @@
     ;; mouse
     [mouse-1] 'link-selected
     ;; misc
-    (kbd "?") 'dictionary-help ; normally under `h` which is rebound here
-    (kbd "C-o") 'dictionary-previous) ; normally under `l` which is rebound here
+    "g?" 'dictionary-help ; normally under `h` which is rebound here
+    (kbd "C-o") 'dictionary-previous)) ; normally under `l` which is rebound here
 
 (provide 'evil-collection-dictionary)
 ;;; evil-collection-dictionary.el ends here


### PR DESCRIPTION
This is for Emacs's standard [dictionary-mode](https://www.emacswiki.org/emacs/DictMode). The actual major mode is named `dictionary-mode` notwithstanding the title of that wiki page.

Dictionary mode binds `h` to `dictionary-help` which shows the default keybindings for the mode - most of which are still active even under the evil bindings so this is still relevant. Since `h` should be bound to `backward-char` under evil, I bound that function to `?`. Is there a convention or precedent to follow here, or is this fine as is?
