### PR TITLE
Suppress dictionary nonexistence error

### DIFF
--- a/modes/dictionary/evil-collection-dictionary.el
+++ b/modes/dictionary/evil-collection-dictionary.el
@@ -28,7 +28,7 @@
 
 ;;; Code:
 (require 'evil-collection)
-(require 'dictionary)
+(require 'dictionary nil t)
 
 (defconst evil-collection-dictionary-maps '(dictionary-mode-map))
 


### PR DESCRIPTION
#411 adds evil bindings to dictionary-mode without `(require 'dictionary nil t)` which will lead an error:

``` text
Cannot open load file: No such file or directory, dictionary
```