### PR TITLE
Add basic support for ripgrep

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,7 +7,6 @@
  (depends-on "evil")
  (depends-on "f")
  (depends-on "ert-runner")
- (depends-on "dictionary")
  (depends-on "package-lint")
  (depends-on "annalist")
  (depends-on "magit"))

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -236,6 +236,7 @@ through removing their entry from `evil-collection-mode-list'."
     reftex
     restclient
     rg
+    ripgrep
     rjsx-mode
     robe
     rtags

--- a/modes/ripgrep/evil-collection-ripgrep.el
+++ b/modes/ripgrep/evil-collection-ripgrep.el
@@ -1,0 +1,45 @@
+;;; evil-collection-ripgrep.el --- Bindings for `ripgrep' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2018 James Nguyen
+
+;; Author: Sid Kasivajhula <sid@countvajhula.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: evil, emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Bindings for `ripgrep'.
+
+;;; Code:
+(require 'evil-collection)
+(require 'ripgrep nil t)
+
+(defconst evil-collection-ripgrep-maps '(ripgrep-search-mode-map))
+
+;;;###autoload
+(defun evil-collection-ripgrep-setup ()
+  "Set up `evil' bindings for `ripgrep'."
+  (evil-collection-define-key 'normal 'ripgrep-search-mode-map
+    "n" 'evil-search-next
+    "\C-j" 'next-error-no-select
+    "\C-k" 'previous-error-no-select))
+
+
+(provide 'evil-collection-ripgrep)
+;;; evil-collection-ripgrep.el ends here

--- a/modes/ripgrep/evil-collection-ripgrep.el
+++ b/modes/ripgrep/evil-collection-ripgrep.el
@@ -37,8 +37,13 @@
   "Set up `evil' bindings for `ripgrep'."
   (evil-collection-define-key 'normal 'ripgrep-search-mode-map
     "n" 'evil-search-next
+    "\C-k" 'previous-error-no-select
     "\C-j" 'next-error-no-select
-    "\C-k" 'previous-error-no-select))
+    "gk" 'previous-error-no-select
+    "gj" 'next-error-no-select
+    "{" 'compilation-previous-file
+    "}" 'compilation-next-file
+    "i" 'wgrep-change-to-wgrep-mode))
 
 
 (provide 'evil-collection-ripgrep)

--- a/modes/ripgrep/evil-collection-ripgrep.el
+++ b/modes/ripgrep/evil-collection-ripgrep.el
@@ -1,7 +1,5 @@
 ;;; evil-collection-ripgrep.el --- Bindings for `ripgrep' -*- lexical-binding: t -*-
 
-;; Copyright (C) 2018 James Nguyen
-
 ;; Author: Sid Kasivajhula <sid@countvajhula.com>
 ;; Maintainer: James Nguyen <james@jojojames.com>
 ;; Pierre Neidhardt <mail@ambrevar.xyz>


### PR DESCRIPTION
[rg](https://github.com/dajva/rg.el) and [deadgrep](https://github.com/Wilfred/deadgrep) are already supported. This adds support for [ripgrep](https://github.com/nlamirault/ripgrep.el), yet another ripgrep frontend, and the one that happens to be [used by projectile](https://github.com/bbatsov/projectile/blob/0ff73ecf7f25f47382e2d28c8ab232c18609d515/projectile.el#L3428-L3437).

I followed the `grep` recipe to add minimal support for navigating the search results.

I also removed `dictionary` from the Cask dependencies since it looks like with [this change](https://github.com/emacs-evil/evil-collection/pull/413), it isn't needed anymore.