### PR TITLE
edebug: "h" should behave the same as j, k, l

### DIFF
--- a/modes/edebug/evil-collection-edebug.el
+++ b/modes/edebug/evil-collection-edebug.el
@@ -44,7 +44,8 @@
 
   (evil-collection-define-key nil 'edebug-mode-map
     "g" nil
-    "G" nil)
+    "G" nil
+    "h" nil)
 
   ;; FIXME: Seems like other minor modes will readily clash with `edebug'.
   ;; `lispyville' and `edebug' 's' key?


### PR DESCRIPTION
j, k, l are used for navigation in edebug-mode and so should do h.
However, currently it performs "edebug-goto-here", which is also bound
to H. Therefore, "h" is free to be used for navigation.