### PR TITLE
Replace ZZ to ebib lower

### DIFF
--- a/modes/ebib/evil-collection-ebib.el
+++ b/modes/ebib/evil-collection-ebib.el
@@ -48,7 +48,7 @@
     "n" 'ebib-search-next
     "p" 'ebib-yank-entry
     "ZQ" 'ebib-quit
-    "ZZ" 'ebib-quit
+    "ZZ" 'ebib-lower
     (kbd "C-u") 'ebib-index-scroll-down
     (kbd "C-d") 'ebib-index-scroll-up
     (kbd "C-b") 'ebib-index-scroll-down


### PR DESCRIPTION
The original ebib involing a function to hide ebib without quit it which can
make some features like completion to work.