### PR TITLE
elfeed: Bind q, ZQ, ZZ to elfeed-search-quit-window

### DIFF
--- a/modes/elfeed/evil-collection-elfeed.el
+++ b/modes/elfeed/evil-collection-elfeed.el
@@ -59,7 +59,12 @@
 
     ;; refresh
     "gR" 'elfeed-search-fetch ; TODO: Which update function is more useful?
-    "gr" 'elfeed-search-update--force)
+    "gr" 'elfeed-search-update--force
+
+    ;; quit
+    "q" 'elfeed-search-quit-window
+    "ZQ" 'elfeed-search-quit-window
+    "ZZ" 'elfeed-search-quit-window)
 
   (evil-collection-define-key '(normal visual) 'elfeed-search-mode-map
     "+" 'elfeed-search-tag-all


### PR DESCRIPTION
elfeed binds `q` to `elfeed-search-quit-window` which saves the db and
quit the window. As today we only close the window which may lead to
data loss.