### PR TITLE
fix: Stop inhibiting company popup when not in evil-mode

### DIFF
--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -63,8 +63,7 @@ be set through custom or before evil-collection loads."
   "Return non-nil if `evil-state' is in supported states."
   (cond
    ((not (bound-and-true-p evil-mode)) t)
-   ((eq command 'prefix)
-    (and (bound-and-true-p evil-mode) (memq evil-state evil-collection-company-supported-states)))
+   ((eq command 'prefix) (memq evil-state evil-collection-company-supported-states))
    (t t)))
 
 ;;;###autoload

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -62,9 +62,9 @@ be set through custom or before evil-collection loads."
 (defun evil-collection-company-supported-p (command &rest _)
   "Return non-nil if `evil-state' is in supported states."
   (cond
+   ((not (bound-and-true-p evil-mode)) t)
    ((eq command 'prefix)
-    (or (and (bound-and-true-p evil-mode) (memq evil-state evil-collection-company-supported-states))
-        (not (bound-and-true-p evil-mode))))
+    (and (bound-and-true-p evil-mode) (memq evil-state evil-collection-company-supported-states)))
    (t t)))
 
 ;;;###autoload

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -63,12 +63,9 @@ be set through custom or before evil-collection loads."
   "Return non-nil if `evil-state' is in supported states."
   (cond
    ((eq command 'prefix)
-    (memq evil-state evil-collection-company-supported-states))
+    (or (and (bound-and-true-p evil-mode) (memq evil-state evil-collection-company-supported-states))
+        (not (bound-and-true-p evil-mode))))
    (t t)))
-
-(defun evil-collection-company-popup ()
-  "When `evil-mode' is active, make `company-mode' not show popup if not in supported state."
-  (advice-add 'company-call-backend :before-while 'evil-collection-company-supported-p))
 
 ;;;###autoload
 (defun evil-collection-company-setup ()
@@ -102,7 +99,7 @@ be set through custom or before evil-collection loads."
       (company-tng-configure-default)))
 
   ;; Make `company-mode' not show popup when not in supported state
-  (add-hook 'evil-mode-hook 'evil-collection-company-popup))
+  (advice-add 'company-call-backend :before-while 'evil-collection-company-supported-p))
 
 
 (provide 'evil-collection-company)

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -62,9 +62,13 @@ be set through custom or before evil-collection loads."
 (defun evil-collection-company-supported-p (command &rest _)
   "Return non-nil if `evil-state' is in supported states."
   (cond
-    ((eq command 'prefix)
-     (memq evil-state evil-collection-company-supported-states))
-    (t t)))
+   ((eq command 'prefix)
+    (memq evil-state evil-collection-company-supported-states))
+   (t t)))
+
+(defun evil-collection-company-popup ()
+  "When `evil-mode' is active, make `company-mode' not show popup if not in supported state."
+  (advice-add 'company-call-backend :before-while 'evil-collection-company-supported-p))
 
 ;;;###autoload
 (defun evil-collection-company-setup ()
@@ -98,7 +102,8 @@ be set through custom or before evil-collection loads."
       (company-tng-configure-default)))
 
   ;; Make `company-mode' not show popup when not in supported state
-  (advice-add 'company-call-backend :before-while 'evil-collection-company-supported-p))
+  (add-hook 'evil-mode-hook 'evil-collection-company-popup))
+
 
 (provide 'evil-collection-company)
 ;;; evil-collection-company.el ends here


### PR DESCRIPTION
The `evil-collection` package inhibits `company-mode` from showing completions when evil-mode
is switched off. This commit will fix it and only activate `evil-collection` advice for `company-mode`
when in `evil-mode`.

If applied, this commit will:
    * Allow `company-mode` to show completions when not in `evil-mode`.
    * Only activate `evil-collection` advice for `company-mode` when in `evil-mode`.
    * Fixes #451 .