### PR TITLE
Add evil-collection-define-operator-key

### DIFF
--- a/modes/elfeed/evil-collection-elfeed.el
+++ b/modes/elfeed/evil-collection-elfeed.el
@@ -107,16 +107,9 @@
     "ZQ" 'elfeed-kill-buffer
     "ZZ" 'elfeed-kill-buffer)
 
-  (evil-collection-define-key 'operator 'elfeed-show-mode-map
-    ;; Like `eww'.
-    "u" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      #'elfeed-show-yank)))))
+  ;; yu, like `eww'
+  (evil-collection-define-operator-key 'yank 'elfeed-show-mode-map
+    "u" 'elfeed-show-yank))
 
 (provide 'evil-collection-elfeed)
 ;;; evil-collection-elfeed.el ends here

--- a/modes/eww/evil-collection-eww.el
+++ b/modes/eww/evil-collection-eww.el
@@ -89,15 +89,8 @@
     "ZQ" 'quit-window
     "ZZ" 'quit-window)
 
-  (evil-collection-define-key 'operator 'eww-mode-map
-    "u" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      #'eww-copy-page-url))))
+  (evil-collection-define-operator-key 'yank 'eww-mode-map
+    "u" 'eww-copy-page-url)
 
   (evil-collection-set-readonly-bindings 'eww-history-mode-map)
   (evil-set-initial-state 'eww-history-mode 'normal)
@@ -128,15 +121,8 @@
     ;; refresh
     "gr" 'revert-buffer)
 
-  (evil-collection-define-key 'operator 'eww-bookmark-mode-map
-    "u" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      #'eww-copy-page-url)))))
+  (evil-collection-define-operator-key 'yank 'eww-bookmark-mode-map
+    "u" 'eww-copy-page-url))
 
 (provide 'evil-collection-eww)
 ;;; evil-collection-eww.el ends here

--- a/modes/info/evil-collection-info.el
+++ b/modes/info/evil-collection-info.el
@@ -113,15 +113,9 @@
     "0" 'evil-digit-argument-or-evil-beginning-of-line
     "gg" 'evil-goto-first-line)
 
-  (evil-collection-define-key 'operator 'Info-mode-map
-    "u" '(menu-item                     ; Like eww.
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      #'Info-copy-current-node-name)))))
+  ;; yu, Like eww.
+  (evil-collection-define-operator-key 'yank 'Info-mode-map
+    "u" 'Info-copy-current-node-name))
 
 (provide 'evil-collection-info)
 ;;; evil-collection-info.el ends here

--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -259,15 +259,10 @@
     "G" 'mu4e-compose-goto-bottom)
   (evil-set-command-property 'mu4e-compose-goto-bottom :keep-visual t)
   (evil-set-command-property 'mu4e-compose-goto-top :keep-visual t)
-  (evil-collection-define-key 'operator 'mu4e-view-mode-map
-    "u" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                '(evil-yank evil-cp-yank evil-sp-yank lispyville-yank))
-                      (setq evil-inhibit-operator t)
-                      #'mu4e-view-save-url)))))
+
+  ;; yu
+  (evil-collection-define-operator-key 'mu4e-view-mode-map
+    "u" 'mu4e-view-save-url))
 
 
 ;;; Update mu4e-main-view

--- a/modes/notmuch/evil-collection-notmuch.el
+++ b/modes/notmuch/evil-collection-notmuch.el
@@ -227,29 +227,13 @@
       "+" 'notmuch-search-add-tag
       (kbd "RET") 'notmuch-search-show-thread))
 
-  (evil-collection-define-key 'operator 'notmuch-search-mode-map
-    ;; Like `eww'.
-    "s"
-    `(menu-item
-      ""
-      nil
-      :filter (lambda (&optional _)
-                (when (memq evil-this-operator
-                            evil-collection-yank-operators)
-                  (setq evil-inhibit-operator t)
-                  #'notmuch-search-stash-map))))
+  ;; ys
+  (evil-collection-define-operator-key 'yank 'notmuch-search-mode-map
+    "s" 'notmuch-search-stash-map)
 
-  (evil-collection-define-key 'operator 'notmuch-show-mode-map
-    ;; Like `eww'.
-    "s"
-    `(menu-item
-      ""
-      nil
-      :filter (lambda (&optional _)
-                (when (memq evil-this-operator
-                            evil-collection-yank-operators)
-                  (setq evil-inhibit-operator t)
-                  #'notmuch-show-stash-map)))))
+  ;; ys
+  (evil-collection-define-operator-key 'yank 'notmuch-show-mode-map
+    "s" 'notmuch-show-stash-map))
 
 (provide 'evil-collection-notmuch)
 ;;; evil-collection-notmuch.el ends here

--- a/modes/pass/evil-collection-pass.el
+++ b/modes/pass/evil-collection-pass.el
@@ -66,42 +66,10 @@ keybindings listed in `evil-collection-pass-command-to-label'."
   (advice-add 'pass--display-keybinding
               :around 'evil-collection-pass-display-keybinding)
 
-  ;; FIXME: #1 This type of binding is duplicated throughout `evil-collection'
-  ;; Maybe define new utility to do these types of bindings that append
-  ;; to (e.g. y or d) operators.
-  ;; FIXME: #2 These types of bindings will slip through the white/blacklist.
-  ;; For example a user may want to set a blacklist for a bind like "yf"
-  ;; but these binds would be registered as "f" in this case.
-  ;; FIXME: #3 Handle [remap evil-yank], etc to be more bulletproof.
-  ;; https://github.com/emacs-evil/evil-collection/pull/91#issuecomment-366181047
-  (evil-collection-define-key 'operator 'pass-mode-map
-    ;; Like `eww'.
-    "f" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      'pass-copy-field)))
-
-    "n" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      'pass-copy-username)))
-
-    "u" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      'pass-copy-url))))
+  (evil-collection-define-operator-key 'yank 'pass-mode-map
+    "f" 'pass-copy-field
+    "n" 'pass-copy-username
+    "u" 'pass-copy-url)
 
   ;; https://github.com/NicolasPetton/pass/pull/47
   (when (fboundp 'pass-edit)

--- a/modes/transmission/evil-collection-transmission.el
+++ b/modes/transmission/evil-collection-transmission.el
@@ -145,17 +145,9 @@
     "P" 'transmission-set-bandwidth-priority
     "r" 'transmission-move)
 
-  (evil-collection-define-key 'operator 'transmission-info-mode-map
-    ;; Like `eww'.
-    "u" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      #'transmission-copy-magnet))))
-
+  ;; yu, Like `eww'.
+  (evil-collection-define-operator-key 'yank 'transmission-info-mode-map
+    "u" 'transmission-copy-magnet)
 
   (evil-collection-set-readonly-bindings 'transmission-peers-mode-map)
   (evil-set-initial-state 'transmission-peers-mode 'normal)

--- a/modes/vdiff/evil-collection-vdiff.el
+++ b/modes/vdiff/evil-collection-vdiff.el
@@ -30,30 +30,24 @@
 (require 'vdiff nil t)
 (require 'evil-collection)
 
+(defconst evil-collection-vdiff-maps '(vdiff-mode-map
+                                       vdiff-3way-mode-map))
+
 ;;;###autoload
 (defun evil-collection-vdiff-setup ()
   "Set up `evil' bindings for `vdiff-mode'."
-  (dolist (mode '(vdiff-mode vdiff-3way-mode))
-    (evil-define-minor-mode-key 'normal mode
+  (add-hook 'vdiff-mode-hook 'evil-normalize-keymaps)
+  (add-hook 'vdiff-3way-mode-hook 'evil-normalize-keymaps)
+
+  (dolist (keymap evil-collection-vdiff-maps)
+    (evil-collection-define-key 'normal keymap
       "]c" 'vdiff-next-hunk
       "[c" 'vdiff-previous-hunk)
 
     ;; define `do' (diff obtain) and `dp' (diff put) bindings
-    (evil-define-minor-mode-key 'operator mode
-      "o" '(menu-item
-            ""
-            nil
-            :filter (lambda (&optional _)
-                      (when (memq evil-this-operator
-                                  evil-collection-delete-operators)
-                        #'vdiff-receive-changes)))
-      "p" '(menu-item
-            ""
-            nil
-            :filter (lambda (&optional _)
-                      (when (memq evil-this-operator
-                                  evil-collection-delete-operators)
-                        #'vdiff-send-changes))))))
+    (evil-collection-define-operator-key 'delete keymap
+      "o" 'vdiff-receive-changes
+      "p" 'vdiff-send-changes)))
 
 (provide 'evil-collection-vdiff)
 

--- a/modes/w3m/evil-collection-w3m.el
+++ b/modes/w3m/evil-collection-w3m.el
@@ -77,24 +77,11 @@
     "ZQ" 'w3m-quit
     "ZZ" 'quit-window)
 
-  (evil-collection-define-key 'operator 'w3m-mode-map
-    "t" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      #'w3m-print-this-url))))
-  (evil-collection-define-key 'operator 'w3m-mode-map
-    "u" '(menu-item
-          ""
-          nil
-          :filter (lambda (&optional _)
-                    (when (memq evil-this-operator
-                                evil-collection-yank-operators)
-                      (setq evil-inhibit-operator t)
-                      #'w3m-print-current-url)))))
+  (evil-collection-define-operator-key 'yank 'w3m-mode-map
+    ;; yt
+    "t" 'w3m-print-this-url
+    ;; yu
+    "u" 'w3m-print-current-url))
 
 (provide 'evil-collection-w3m)
 ;;; evil-collection-w3m.el ends here


### PR DESCRIPTION
Some context: https://github.com/emacs-evil/evil-collection/pull/91#issuecomment-366181047

https://github.com/emacs-evil/evil-collection/commit/6bdbcccf1e4f51c75f5cf54b3dc27419b32fe608

This is for attaching additional keys to operator commands.

e.g. Add "f" to prefix/operator (evil-yank) "y" to get

"yf"

while still maintaining the other operator commands like "yy".

Would be happy if you had time to take a look @noctuid, curious if general has something already for this use case.

@condy0919 Appreciate a look before I merge.