### PR TITLE
fix: don't set repeat with ]l and [l error jump

### DIFF
--- a/modes/unimpaired/evil-collection-unimpaired.el
+++ b/modes/unimpaired/evil-collection-unimpaired.el
@@ -151,6 +151,8 @@
 (defun evil-collection-unimpaired-setup ()
   "Set up unimpaired-like bindings."
   (global-evil-collection-unimpaired-mode 1)
+  (evil-add-command-properties 'evil-collection-unimpaired-next-error :repeat nil)
+  (evil-add-command-properties 'evil-collection-unimpaired-previous-error :repeat nil)
   (evil-collection-define-key 'normal 'evil-collection-unimpaired-mode-map
     "[b" 'evil-prev-buffer
     "]b" 'evil-next-buffer


### PR DESCRIPTION
Currently when you use `]l` or `[l`, moving to next/previous error gets set as the vim repeat, so hitting `.` after `]l` will repeat jumping to the next error. As this is just a motion and not an actual edit, it breaks expectations as to what `.` should do, and prevents you from jumping from error to error, visually assessing them quickly, and using `.` to fix them if they are broken in the same way by doing things like `]l.]l.]l.]l.]l.`.

Using `evil-without-repeat` seems to fix it for me when testing locally, but I'm not sure if there's a more proper way of doing this in an `evil-collection` context.

Thanks for the great work!