### PR TITLE
Fix escape in in emacs-state, yet preserving minibuffer quit functionality

### DIFF
--- a/modes/ivy/evil-collection-ivy.el
+++ b/modes/ivy/evil-collection-ivy.el
@@ -37,7 +37,7 @@
 ;;;###autoload
 (defun evil-collection-ivy-setup ()
   "Set up `evil' bindings for `ivy-mode'."
-  (evil-collection-define-key nil 'ivy-mode-map
+  (evil-collection-define-key nil 'ivy-minibuffer-map
     (kbd "<escape>") 'minibuffer-keyboard-quit)
   (evil-collection-define-key 'normal 'ivy-occur-mode-map
     [mouse-1] 'ivy-occur-click


### PR DESCRIPTION
This PR fixes issue #474 (also raised by me).

This fixes the problem: If a user switches to Emacs mode/evil-emacs-state (quite useful for editing magit commit messages, or working in vterm/term), the `<escape>` key cannot work its classic Meta-functionalities, such as interpreting `<escape> f` as `M-f`, or `<escape> b` as `M-b`.

For further details, please kindly refer to issue #474.