### PR TITLE
Magit: Properly format rebase instructions when commentChar is "%"

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -508,7 +508,8 @@ denotes the original magit key for this command.")
                (flush-lines (concat "^" (regexp-quote comment-start) ".+ = "))
                (dolist (cmd evil-collection-magit-rebase-commands-w-descriptions)
                  (insert
-                  (format (concat comment-start " %-8s %s\n")
+                  (format "%s %-8s %s\n"
+                          comment-start 
                           (if (and (car cmd)
                                    (eq (nth 1 cmd)
                                        (lookup-key aux-map (kbd (car cmd)))))


### PR DESCRIPTION
This change adjusts the formatting of the instructions in the `git-rebase`
buffer to allow them to be properly formatted when git's `core.commentChar` is
set to `%`.  In particular, lines will look something like this:

```
%-8s p
```

The root cause seems to be the how the lines are constructed: comment characters
are directly added to the format string.  When it is `%`, `format` appears to
proceed until it finds the next `%` character, (corresponding to the `%` in
`%-8s`) above and prints it directly to the string rather than interpreting it
something to format.

This is fixed by constructing the format string with the comment character as an
argument to `format` rather than being added directly to the format string.

Fixes #468.