### PR TITLE
Fix Jd binding

### DIFF
--- a/modes/prodigy/evil-collection-prodigy.el
+++ b/modes/prodigy/evil-collection-prodigy.el
@@ -65,7 +65,7 @@
     "in" 'prodigy-add-name-filter
     "I" 'prodigy-clear-filters
     "Jm" 'prodigy-jump-magit
-    "Jd" 'prodigy-jump-dired
+    "Jd" 'prodigy-jump-file-manager
 
     "gj" 'prodigy-next-with-status
     "gk" 'prodigy-prev-with-status


### PR DESCRIPTION
`prodigy-jump-dired` does not exist. `prodigy-jump-file-manager` is
likely the intended function.