### PR TITLE
Docstring: evil-collection-magit-use-y-for-yank

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -65,13 +65,14 @@
                                        magit-submodule-list-mode-map))
 
 (defcustom evil-collection-magit-use-y-for-yank t
-  "When non nil, replace \"y\" for `magit-show-refs-popup' with
-\"yy\" for `evil-collection-magit-yank-whole-line', `ys'
-`magit-copy-section-value', \"yb\" for
-`magit-copy-buffer-revision' and \"yr\" for
-`magit-show-refs-popup'. This keeps \"y\" for
-`magit-show-refs-popup' in the help
-popup (`magit-dispatch-popup'). Default is t."
+  "When non nil (Default is t),
+replace \"y\" for `magit-show-refs' with
+\"yy\" for `evil-collection-magit-yank-whole-line',
+\"ys\" for `magit-copy-section-value',
+\"yb\" for `magit-copy-buffer-revision' and
+\"yr\" for `magit-show-refs'.
+This keeps \"y\" for `magit-show-refs',
+in the help popup (`magit-dispatch')."
   :group 'magit
   :type 'boolean)
 


### PR DESCRIPTION
`magit-show-refs-popup` and `magit-dispatch-popup`
have been renamed without "-popup".

Define magit-show-refs as a transient command
https://github.com/magit/magit/commit/c3135cdb23e223ebf8f3c802616ebb81103fdbe9

Define magit-dispatch as a transient command
https://github.com/magit/magit/commit/dde9a5b77a483fa35d932aecd22c1a4c954ce77e

And make the docstring more readable,
with the related key and command on the same line.

### Notes
This variable name contains: `magit-dispatch-popup`
https://github.com/emacs-evil/evil-collection/blob/09b165d4c2ecac66224f674966c920c25d20f3f6/modes/magit/evil-collection-magit.el#L557

and it's used here:
https://github.com/emacs-evil/evil-collection/blob/09b165d4c2ecac66224f674966c920c25d20f3f6/modes/magit/evil-collection-magit.el#L613

I don't know if it also should be renamed.