### PR TITLE
Tide/references mode: Go to reference at cursor

### DIFF
--- a/modes/tide/evil-collection-tide.el
+++ b/modes/tide/evil-collection-tide.el
@@ -47,7 +47,7 @@
     "gk" 'tide-find-previous-reference
     (kbd "C-j") 'tide-find-next-reference
     (kbd "C-k") 'tide-find-previous-reference
-    (kbd "RET") 'tide-goto-reference
+    (kbd "RET") 'tide-goto-line-reference
     ;; quit
     "q" 'quit-window)
 


### PR DESCRIPTION
Current implementation seems to only work for the first reference in a file. This patch should fix that.