### PR TITLE
reflex: update documentation

### DIFF
--- a/modes/reftex/evil-collection-reftex.el
+++ b/modes/reftex/evil-collection-reftex.el
@@ -87,7 +87,7 @@
     .          In other window, show position from where `reftex-toc' was called.
     rl         Global search and replace to rename label at point.
     x          Switch to TOC of external document (with LaTeX package `xr').
-    gs         Jump to a specific section (e.g. '3 gs' goes to section 3).")
+    J          Jump to a specific section (e.g. '3 J' goes to section 3).")
 
 ;;;###autoload
 (defun evil-collection-reftex-setup ()


### PR DESCRIPTION
A [recent commit](https://github.com/emacs-evil/evil-collection/commit/8244f8806ecb52574827ec30d3c9cda7d8a8e67c) remapped reflex-toc-jump from `gs` -> `J`, but the help didn't get updated (so it erroneously still suggests using `gs` to jump to section). 