### PR TITLE
Make filtering states possible

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -410,7 +410,7 @@ binding in `annalist' as so."
   "Return a list states after filtering STATE (a single symbol or list of symbols).
 The return value adheres to `evil-collection-state-passlist' and
 `evil-collection-state-denylist'. When the STATE is `nil', which
-mean all states for `evil-define-key', return `nil'."
+means all states for `evil-define-key', return `nil'."
   (let ((states (if (listp state) state (list state))))
     (seq-difference
      (if evil-collection-state-passlist

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -321,6 +321,23 @@ This is a list of strings that are suitable for input to `kbd'."
   :type '(repeat string)
   :group 'evil-collection)
 
+(defcustom evil-collection-state-passlist '()
+  "List of evil states that may be used by Evil Collection.
+This is a list of symbols that are suitable for input to
+ `evil-define-key'. Ignore when there are no states in the list."
+  :type '(repeat symbol)
+  :group 'evil-collection)
+
+(defcustom evil-collection-state-denylist
+  (if (bound-and-true-p evil-disable-insert-state-bindings)
+      '(insert)
+    '())
+  "List of evil states that may not be used by Evil Collection.
+This is a list of symbols that are suitable for input to
+ `evil-define-key'."
+  :type '(repeat symbol)
+  :group 'evil-collection)
+
 (defvar evil-collection-setup-hook nil
   "Hook run by `evil-collection-init' for each mode that is evilified.
 This hook runs after all setup (including keybindings) for a mode has already
@@ -388,6 +405,18 @@ binding in `annalist' as so."
     (setq filtered-bindings (nreverse filtered-bindings))
     (evil-collection--define-key 'operator map-sym filtered-bindings)))
 
+(defun evil-collection--filter-states (state)
+  "Return a list states after filtering STATE (a single symbol or list of symbols).
+The return value adheres to `evil-collection-state-passlist' and
+`evil-collection-state-denylist'. When the STATE is `nil', which
+mean all states for `evil-define-key', return `nil'."
+  (let ((states (if (listp state) state (list state))))
+    (seq-difference
+     (if evil-collection-state-passlist
+         (seq-intersection states evil-collection-state-passlist)
+       states)
+     evil-collection-state-denylist)))
+
 (defun evil-collection-define-key (state map-sym &rest bindings)
   "Wrapper for `evil-define-key*' with additional features.
 Unlike `evil-define-key*' MAP-SYM should be a quoted keymap other than the
@@ -397,20 +426,22 @@ to filter keys on the basis of `evil-collection-key-whitelist' and
   (declare (indent defun))
   (let* ((whitelist (mapcar 'kbd evil-collection-key-whitelist))
          (blacklist (mapcar 'kbd evil-collection-key-blacklist))
+         (states-to-bind (evil-collection--filter-states state))
          filtered-bindings)
-    (while bindings
-      (let ((key (pop bindings))
-            (def (pop bindings)))
-        (when (or (and whitelist (member key whitelist))
-                  (not (member key blacklist)))
-          (annalist-record 'evil-collection 'keybindings
-                           (list map-sym state key def)
-                           :local (or (eq map-sym 'local)
-                                      (local-variable-p map-sym)))
-          (push key filtered-bindings)
-          (push def filtered-bindings))))
-    (setq filtered-bindings (nreverse filtered-bindings))
-    (evil-collection--define-key state map-sym filtered-bindings)))
+    (when (or states-to-bind (null state))
+      (while bindings
+        (let ((key (pop bindings))
+              (def (pop bindings)))
+          (when (or (and whitelist (member key whitelist))
+                    (not (member key blacklist)))
+            (annalist-record 'evil-collection 'keybindings
+                             (list map-sym state key def)
+                             :local (or (eq map-sym 'local)
+                                        (local-variable-p map-sym)))
+            (push key filtered-bindings)
+            (push def filtered-bindings))))
+      (setq filtered-bindings (nreverse filtered-bindings))
+      (evil-collection--define-key states-to-bind map-sym filtered-bindings))))
 
 (defun evil-collection--define-key (state map-sym bindings)
   "Workhorse function for `evil-collection-define-key'.

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -36,6 +36,7 @@
 (require 'cl-lib)
 (require 'evil)
 (require 'annalist)
+(require 'seq)
 
 (defvar evil-collection-base-dir (file-name-directory load-file-name)
   "Store the directory evil-collection.el was loaded from.")

--- a/test/evil-collection-test.el
+++ b/test/evil-collection-test.el
@@ -5,4 +5,37 @@
   "Zero check blank test."
   (should (equal 0 0)))
 
+(ert-deftest evil-collection-filtering-states-test ()
+  "Test `evil-collection--filter-states'."
+  (let ((evil-collection-state-denylist '())
+        (evil-collection-state-passlist '()))
+    (should
+     (equal nil
+            (evil-collection--filter-states nil)))
+    (should
+     (equal '(normal)
+            (evil-collection--filter-states 'normal)))
+    (should
+     (equal '(normal)
+            (evil-collection--filter-states '(normal)))))
+  (let ((evil-collection-state-denylist '(insert))
+        (evil-collection-state-passlist '()))
+    (should
+     (equal '()
+            (evil-collection--filter-states 'insert)))
+    (should
+     (equal '(visual)
+            (evil-collection--filter-states '(visual insert)))))
+  (let ((evil-collection-state-denylist '(insert))
+        (evil-collection-state-passlist '(normal visual)))
+    (should
+     (equal '()
+            (evil-collection--filter-states '())))
+    (should
+     (equal '(visual)
+            (evil-collection--filter-states '(insert visual))))
+    (should
+     (seq-set-equal-p '(visual normal)
+                      (evil-collection--filter-states '(motion normal visual insert))))))
+
 ;;; evil-collection-test.el ends here


### PR DESCRIPTION
Solves #465 by defining `evil-collection-state-passlist` and `evil-collection-state-denylist` analogous to `evil-collection-key-{black,white}list`.

If you find the new variable names alien to the latter's, please tell me to rename them. I also prefer the old naming scheme but have seen the trend such as `native-comp-deferred-compilation-deny-list`.