### PR TITLE
Properly bind escape in magit-mode-map

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -320,7 +320,7 @@ moment.")
        (,states magit-mode-map ,(kbd "S-DEL") magit-diff-show-or-scroll-down "DEL")
 
        ((,evil-collection-magit-state) magit-mode-map ,(kbd evil-toggle-key) evil-emacs-state)
-       ((,evil-collection-magit-state) magit-mode-map "<escape>" magit-mode-bury-buffer))
+       ((,evil-collection-magit-state) magit-mode-map ,(kbd "<escape>") magit-mode-bury-buffer))
 
      (if (eq evil-search-module 'evil-search)
          `((,states magit-mode-map "/" evil-ex-search-forward)


### PR DESCRIPTION
Without using `kbd', each key in the string "\<escape>" is interpreted as a
prefix key.