### PR TITLE
[elfeed]: add missing keybind

### DIFF
--- a/modes/elfeed/evil-collection-elfeed.el
+++ b/modes/elfeed/evil-collection-elfeed.el
@@ -56,6 +56,7 @@
     ;; filter
     "s" 'elfeed-search-live-filter
     "S" 'elfeed-search-set-filter
+    "c" 'elfeed-search-clear-filter
 
     ;; refresh
     "gR" 'elfeed-search-fetch ; TODO: Which update function is more useful?


### PR DESCRIPTION
The command that resets the search filter to it's default value, `elfeed-search-clear-filter`, was missing it's keybinding.
elfeed bind this to `c` by default.