### PR TITLE
debug: added bindings for toggling multi-line

### DIFF
--- a/modes/debug/evil-collection-debug.el
+++ b/modes/debug/evil-collection-debug.el
@@ -66,7 +66,10 @@
     "p" (if (fboundp 'debugger-toggle-locals)
             'debugger-toggle-locals
           'backtrace-toggle-locals)
-
+    
+    "zo" 'backtrace-multi-line
+    "zc" 'backtrace-single-line
+    
     ;; quit
     "q" 'top-level
     "ZQ" 'evil-quit


### PR DESCRIPTION
Debugger mode bindings for backtrace-multi-line and backtrace-single-line.