### PR TITLE
magit: fix use-z-for-folds

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -563,7 +563,8 @@ evil-collection-magit affects.")
 (defvar evil-collection-magit-popup-changes
   (append
    (when evil-collection-magit-use-z-for-folds
-     '((magit-dispatch "z" "Z" magit-stash)))
+     '((magit-dispatch "Z" "%" magit-worktree)
+       (magit-dispatch "z" "Z" magit-stash)))
    (when evil-collection-magit-want-horizontal-movement
      '((magit-dispatch "L" "\C-l" magit-log-refresh)
        (magit-dispatch "l" "L" magit-log)))


### PR DESCRIPTION
`magit-worktree` has been moved from "%" to "Z" in transient prefix
`magit-dispatch` in commit [9bec1c54ab0705eb68ae4aa6c8a0498999a018f6](https://github.com/magit/magit/commit/9bec1c54ab0705eb68ae4aa6c8a0498999a018f6).

When mapping `magit-stash` to Z in `magit-dispatch` due to
`evil-collection-magit-use-z-for-folds`, first move `magit-worktree` back to
its original keybinding to avoid collision.

In my case Z would correctly display as Stash in magit-dispatch, but pressing the key would still call magit-worktree.