### PR TITLE
mu4e: update binding for attachment actions

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -206,7 +206,7 @@
      "P" mu4e-view-save-attachment-multi ; Since mu4e 1.0, -multi is same as normal.
      "O" mu4e-headers-change-sorting
      "o" mu4e-view-open-attachment
-     "A" mu4e-view-attachment-action
+     "A" mu4e-view-mime-part-action ; Since 1.6, uses gnus view by default
      "a" mu4e-view-action
      "J" mu4e~headers-jump-to-maildir
      "[[" mu4e-view-headers-prev-unread


### PR DESCRIPTION
As part of the move to the gnus viewer for emails, the command name has been
changed from `mu4e-view-attachment-action` to `mu4e-view-mime-part-actions`.

https://github.com/djcb/mu/issues/2101#issuecomment-903074743