### PR TITLE
selectrum: add initial support

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -239,6 +239,7 @@ This will bind additional find-* type commands, e.g. usages, assignments, etc.."
     rtags
     ruby-mode
     scroll-lock
+    selectrum
     sh-script
     ,@(when (>= emacs-major-version 28) '(shortdoc))
     simple

--- a/modes/selectrum/evil-collection-selectrum.el
+++ b/modes/selectrum/evil-collection-selectrum.el
@@ -1,0 +1,67 @@
+;;; evil-collection-selectrum.el --- Evil bindings for Selectrum -*- lexical-binding: t -*-
+
+;; Copyright (C) 2021 Balaji Sivaraman
+
+;; Author: Balaji Sivaraman <balaji@balajisivaraman.com>
+;; Maintainer: Balaji Sivaraman <balaji@balajisivaraman.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: evil, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil bindings for Selectrum.
+
+;;; Code:
+
+(require 'evil-collection)
+(require 'selectrum nil t)
+
+(defconst evil-collection-selectrum-maps '(selectrum-minibuffer-map))
+
+;;;###autoload
+(defun evil-collection-selectrum-setup ()
+  "Set up `evil' bindings for `selectrum-mode'."
+
+  (defvar evil-collection-setup-minibuffer)
+  (when evil-collection-setup-minibuffer
+    (evil-collection-define-key '(insert normal) 'selectrum-minibuffer-map
+      (kbd "C-b") 'selectrum-previous-page
+      (kbd "C-f") 'selectrum-next-page
+      (kbd "M-RET") 'selectrum-submit-exact-input
+      (kbd "<return>") 'selectrum-select-current-candidate)
+
+    (evil-collection-define-key 'insert 'selectrum-minibuffer-map
+      (kbd "C-j") 'selectrum-next-candidate
+      (kbd "C-k") 'selectrum-previous-candidate
+      (kbd "C-n") 'selectrum-next-candidate
+      (kbd "C-p") 'selectrum-previous-candidate)
+
+    (evil-collection-define-key 'normal 'selectrum-minibuffer-map
+      (kbd "j") 'selectrum-next-candidate
+      (kbd "k") 'selectrum-previous-candidate)
+
+    (when evil-want-C-u-scroll
+      (evil-collection-define-key '(insert normal) 'selectrum-minibuffer-map
+        (kbd "C-u") 'selectrum-previous-page))
+
+    (when evil-want-C-d-scroll
+      (evil-collection-define-key '(insert normal) 'selectrum-minibuffer-map
+        (kbd "C-d") 'selectrum-next-page))))
+
+(provide 'evil-collection-selectrum)
+;;; evil-collection-selectrum.el ends here


### PR DESCRIPTION
Hey,

First of all, thanks for the truly wonderful package. My jump to Evil Mode (again!) wouldn't be complete without it.

In this PR, I have added basic support for [Selectrum](https://github.com/raxod502/selectrum), which I found to be lacking here.

I have tried my best to mimic either Helm or Ivy keybindings with this PR. I don't see `C-j` and `C-k` being bound for navigating between candidates in Ivy or Helm. However, I have found it to be useful. I can remove this if it goes against normal Evil Collection semantics.

Open to any other suggestions or changes. Thanks again.