### PR TITLE
comint: Bind comint-kill-input to C-u

### DIFF
--- a/modes/comint/evil-collection-comint.el
+++ b/modes/comint/evil-collection-comint.el
@@ -50,6 +50,11 @@
     (kbd "C-p") #'comint-previous-input
     (kbd "C-n") #'comint-next-input)
 
+  ;; TODO: What if the user changes `evil-want-C-u-delete' after this is run?
+  (when evil-want-C-u-delete
+    (evil-collection-define-key 'insert 'comint-mode-map
+      (kbd "C-u") #'comint-kill-input))
+
   (evil-collection-define-key 'insert 'comint-mode-map
     (kbd "<up>") #'comint-previous-input
     (kbd "<down>") #'comint-next-input))


### PR DESCRIPTION
In Vim insert mode, C-u deletes to the beginning of the line, so we
make an analogous binding for comint buffers.