### PR TITLE
consult: implement jump-list command

### DIFF
--- a/modes/consult/evil-collection-consult.el
+++ b/modes/consult/evil-collection-consult.el
@@ -48,11 +48,13 @@
 (declare-function consult--remove-dups "consult")
 (declare-function consult--mark-candidates "consult")
 (declare-function consult-mark "consult")
+(declare-function consult-global-mark "consult")
 
 (defun evil-collection-consult-set-bindings ()
   "Set the bindings."
   (evil-set-command-property 'consult-outline :jump t)
   (evil-set-command-property 'consult-mark :jump t)
+  (evil-set-command-property 'consult-global-mark :jump t)
   (evil-set-command-property 'consult-imenu :jump t)
   (evil-set-command-property 'consult-org-heading :jump t)
   (evil-set-command-property 'consult-line :jump t))
@@ -95,6 +97,16 @@ as defined in `evil-collection-consult--evil-mark-ring'."
   (cl-letf (((symbol-function 'consult--mark-candidates)
              #'evil-collection-consult--mark-candidates))
     (consult-mark (evil-collection-consult--evil-mark-ring))))
+
+;;;###autoload
+(defun evil-collection-consult-jump-list ()
+  "Jump to a position in the evil jump list."
+  (interactive)
+  (consult-global-mark (delq nil (mapcar (lambda (jump)
+                                           (let ((mark (car jump)))
+                                             (when (markerp mark)
+                                               mark)))
+                                         (ring-elements (evil--jumps-get-window-jump-list))))))
 
 ;;;###autoload
 (defun evil-collection-consult-setup ()

--- a/modes/consult/evil-collection-consult.el
+++ b/modes/consult/evil-collection-consult.el
@@ -92,13 +92,9 @@ as defined in `evil-collection-consult--evil-mark-ring'."
 (defun evil-collection-consult-mark ()
   "Jump to an evil marker in the current buffer."
   (interactive)
-  (unwind-protect
-      (progn
-        (advice-add #'consult--mark-candidates :override
-                    #'evil-collection-consult--mark-candidates)
-        (consult-mark (evil-collection-consult--evil-mark-ring)))
-    (advice-remove #'consult--mark-candidates
-                   #'evil-collection-consult--mark-candidates)))
+  (cl-letf (((symbol-function 'consult--mark-candidates)
+             #'evil-collection-consult--mark-candidates))
+    (consult-mark (evil-collection-consult--evil-mark-ring))))
 
 ;;;###autoload
 (defun evil-collection-consult-setup ()


### PR DESCRIPTION
This PR implements a consult command which allows you to browse the evil jump list with consult preview and completion.

In a separate commit, I've also simplified the implementation of evil-collection-consult-mark a bit by removing unnecessary usage of advice. This can be dropped or moved to a separate PR depending on maintainers' preference.

Thanks in advance.