### PR TITLE
Ctrl x bindings

### DIFF
--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -32,6 +32,7 @@
 
 (declare-function company-tng-mode "company-tng")
 (declare-function company-grab-line "company")
+(declare-function company-begin-backend "company")
 
 (defgroup evil-collection-company nil
   "Evil bindings for `company-mode'."

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -31,6 +31,7 @@
 (require 'evil-collection)
 
 (declare-function company-tng-mode "company-tng")
+(declare-function company-grab-line "company")
 
 (defgroup evil-collection-company nil
   "Evil bindings for `company-mode'."
@@ -39,10 +40,9 @@
 (defcustom evil-collection-company-supported-states '(insert replace emacs)
   "The `evil-state's which `company' function can be requested."
   :type '(repeat symbol))
-(defcustom evil-want-company-extended-keybindings nil
+(defcustom evil-collection-want-company-extended-keybindings nil
   "The 'evil-company-extended' keybindings shoould be requested"
-  :type 'boolean
-  )
+  :type 'boolean)
 
 (defvar company-active-map)
 (defvar company-search-map)
@@ -58,13 +58,13 @@
    (t t)))
 
 ;;;###autoload
-(defun +company/whole-lines (command &optional arg &rest ignored)
+(defun evil-collection-company-whole-lines (command &optional arg &rest ignored)
   "`company-mode' completion backend that completes whole-lines, akin to vim's
 C-x C-l."
   (interactive (list 'interactive))
   (require 'company)
   (pcase command
-    (`interactive (company-begin-backend '+company/whole-lines))
+    (`interactive (company-begin-backend 'evil-collection-company-whole-lines))
     (`prefix      (company-grab-line "^[\t\s]*\\(.+\\)" 1))
     (`candidates
      (all-completions
@@ -88,9 +88,9 @@ C-x C-l."
     (kbd "M-j") 'company-select-next
     (kbd "M-k") 'company-select-previous)
 
-  (when evil-want-company-extended-keybindings 
+  (when evil-collection-want-company-extended-keybindings 
     (evil-collection-define-key nil 'company-active-map
-      (kbd "C-l") '+company/whole-lines
+      (kbd "C-l") 'evil-collection-company-whole-lines
       (kbd "C-]") 'company-etags
       (kbd "C-f") 'company-files
       (kbd "C-o") 'company-capf

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -98,8 +98,8 @@ C-x C-l."
     (kbd "C-]") 'company-etags
     (kbd "C-f") 'company-files
     (kbd "C-o") 'company-capf
-    (kbd "C-s") 'company-ispell
-    )
+    (kbd "C-s") 'company-ispell)
+
   (when evil-want-C-u-scroll
     (evil-collection-define-key nil 'company-active-map
       (kbd "C-u") 'company-previous-page))

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -39,6 +39,9 @@
 (defcustom evil-collection-company-supported-states '(insert replace emacs)
   "The `evil-state's which `company' function can be requested."
   :type '(repeat symbol))
+(defcustom evil-want-company-extended-bindings nil
+  "The 'evil-company-extended' keybindings shoould be requested"
+  )
 
 (defvar company-active-map)
 (defvar company-search-map)
@@ -74,15 +77,6 @@ C-x C-l."
         "\\(\r\n\\|[\n\r]\\)" t))))))
 
 ;;;###autoload
-(defun +company/dict-or-keywords ()
-  "`company-mode' completion combining `company-dict' and `company-keywords'."
-  (interactive)
-  (require 'company-dict)
-  (require 'company-keywords)
-  (let ((company-backends '((company-keywords company-dict))))
-    (call-interactively #'company-complete)))
-
-;;;###autoload
 (defun evil-collection-company-setup ()
   "Set up `evil' bindings for `company'."
   (evil-collection-define-key nil 'company-active-map
@@ -93,12 +87,13 @@ C-x C-l."
     (kbd "M-j") 'company-select-next
     (kbd "M-k") 'company-select-previous)
 
-  (evil-collection-define-key nil 'company-active-map
-    (kbd "C-l") '+company/whole-lines
-    (kbd "C-]") 'company-etags
-    (kbd "C-f") 'company-files
-    (kbd "C-o") 'company-capf
-    (kbd "C-s") 'company-ispell)
+  (when evil-want-extended-company-keybindings 
+    (evil-collection-define-key nil 'company-active-map
+      (kbd "C-l") '+company/whole-lines
+      (kbd "C-]") 'company-etags
+      (kbd "C-f") 'company-files
+      (kbd "C-o") 'company-capf
+      (kbd "C-s") 'company-ispell))
 
   (when evil-want-C-u-scroll
     (evil-collection-define-key nil 'company-active-map

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -41,6 +41,7 @@
   :type '(repeat symbol))
 (defcustom evil-want-company-extended-bindings nil
   "The 'evil-company-extended' keybindings shoould be requested"
+  :type 'boolean
   )
 
 (defvar company-active-map)

--- a/modes/company/evil-collection-company.el
+++ b/modes/company/evil-collection-company.el
@@ -39,7 +39,7 @@
 (defcustom evil-collection-company-supported-states '(insert replace emacs)
   "The `evil-state's which `company' function can be requested."
   :type '(repeat symbol))
-(defcustom evil-want-company-extended-bindings nil
+(defcustom evil-want-company-extended-keybindings nil
   "The 'evil-company-extended' keybindings shoould be requested"
   :type 'boolean
   )
@@ -88,7 +88,7 @@ C-x C-l."
     (kbd "M-j") 'company-select-next
     (kbd "M-k") 'company-select-previous)
 
-  (when evil-want-extended-company-keybindings 
+  (when evil-want-company-extended-keybindings 
     (evil-collection-define-key nil 'company-active-map
       (kbd "C-l") '+company/whole-lines
       (kbd "C-]") 'company-etags


### PR DESCRIPTION
Adds Cntrl-X bindings according to #308 for company completion in evil-mode.

Currently added
- C-o: company-capf
- C-]: company-etags
- C-s: company-ispell
- C-f: company-files.

Notable missing keybindings
- company-dict-or-keywords (C-k is taken).

The `+company/whole-lines`  and other `+company` functions is taken directly from `doom-emacs`. It works without problem in my own emacs configuration.

Changes are welcome!