### PR TITLE
notmuch: use notmuch-tree-archive-thread-then-next in tree view

### DIFF
--- a/modes/notmuch/evil-collection-notmuch.el
+++ b/modes/notmuch/evil-collection-notmuch.el
@@ -189,7 +189,7 @@
     "K" 'notmuch-tag-jump
     (kbd "RET") 'notmuch-tree-show-message
     [mouse-1] 'notmuch-tree-show-message
-    "A" 'notmuch-tree-archive-thread
+    "A" 'notmuch-tree-archive-thread-then-next
     "a" 'notmuch-tree-archive-message-then-next
     "s" 'notmuch-tree-to-tree
     "gj" 'notmuch-tree-next-matching-message


### PR DESCRIPTION
Default notmuch keymaps bind A to
notmuch-tree-archive-thread-then-next in both notmuch-show-mode and
notmuch-tree-mode.