### PR TITLE
xwidget: enhanced d/u

### DIFF
--- a/modes/xwidget/evil-collection-xwidget.el
+++ b/modes/xwidget/evil-collection-xwidget.el
@@ -1,6 +1,6 @@
 ;;; evil-collection-xwidget.el --- Evil bindings for Xwidget -*- lexical-binding: t -*-
 
-;; Copyright (C) 2020 Ruslan Kamashev
+;; Copyright (C) 2020, 2021 Ruslan Kamashev
 
 ;; Author: Ruslan Kamashev <rynffoll@gmail.com>
 ;; Maintainer: James Nguyen <james@jojojames.com>
@@ -32,35 +32,61 @@
 
 (defvar evil-collection-xwidget-maps '(xwidget-webkit-mode-map))
 
+(defmacro evil-collection-xwidget-half-page-height ()
+  "Return Emacs xwidget half window height in pixel."
+  (/ (xwidget-window-inside-pixel-height (selected-window)) 2))
+
+(defun evil-collection-xwidget-webkit-scroll-up-half-page ()
+  "Scroll webkit up by half page."
+  (interactive)
+  (xwidget-webkit-scroll-up (evil-collection-xwidget-half-page-height)))
+
+(defun evil-collection-xwidget-webkit-scroll-down-half-page ()
+  "Scroll webkit down by half page."
+  (interactive)
+  (xwidget-webkit-scroll-down (evil-collection-xwidget-half-page-height)))
+
 ;;;###autoload
 (defun evil-collection-xwidget-setup ()
   "Set up `evil' bindings for `xwidget'."
+  (evil-collection-set-readonly-bindings 'xwidget-webkit-mode-map)
   (evil-collection-define-key 'normal 'xwidget-webkit-mode-map
-    "q" 'quit-window
-    "k" 'xwidget-webkit-scroll-down-line
-    "j" 'xwidget-webkit-scroll-up-line
-    "h" 'xwidget-webkit-scroll-backward
-    "l" 'xwidget-webkit-scroll-forward
+    ;; motion
+    ;;
+    ;; d/u are widely used in browser extension vimium.
+    "j"         'xwidget-webkit-scroll-up-line
+    "k"         'xwidget-webkit-scroll-down-line
+    "h"         'xwidget-webkit-scroll-backward
+    "l"         'xwidget-webkit-scroll-forward
     (kbd "C-f") 'xwidget-webkit-scroll-up
     (kbd "C-b") 'xwidget-webkit-scroll-down
-    "+" 'xwidget-webkit-zoom-in
-    "=" 'xwidget-webkit-zoom-in
-    "-" 'xwidget-webkit-zoom-out
-    "R" 'xwidget-webkit-reload
-    "gr" 'xwidget-webkit-reload
-    "H" 'xwidget-webkit-back
-    "L" 'xwidget-webkit-forward
-    "gu" 'xwidget-webkit-browse-url
-    "gg" 'xwidget-webkit-scroll-top
-    "G" 'xwidget-webkit-scroll-bottom
-    "y" 'xwidget-webkit-copy-selection-as-kill)
+    "d"         'evil-collection-xwidget-webkit-scroll-up-half-page
+    "u"         'evil-collection-xwidget-webkit-scroll-down-half-page
+    "gg"        'xwidget-webkit-scroll-top
+    "G"         'xwidget-webkit-scroll-bottom
+    ;; history browsing
+    "H"         'xwidget-webkit-back
+    "L"         'xwidget-webkit-forward
+    "B"         'xwidget-webkit-browse-history
+    ;; zoom
+    "+"         'xwidget-webkit-zoom-in
+    "="         'xwidget-webkit-zoom-in
+    "-"         'xwidget-webkit-zoom-out
+    ;; loading
+    "R"         'xwidget-webkit-reload
+    "gr"        'xwidget-webkit-reload
+    ;; misc
+    (kbd "RET") 'xwidget-webkit-insert-string
+    "A"         'xwidget-webkit-adjust-size-dispatch
+    "gu"        'xwidget-webkit-browse-url
+    "W"         'xwidget-webkit-current-url)
 
   (when evil-want-C-d-scroll
     (evil-collection-define-key 'normal 'xwidget-webkit-mode-map
-      (kbd "C-d") 'xwidget-webkit-scroll-up))
+      (kbd "C-d") 'evil-collection-xwidget-webkit-scroll-up-half-page))
   (when evil-want-C-u-scroll
     (evil-collection-define-key 'normal 'xwidget-webkit-mode-map
-      (kbd "C-u") 'xwidget-webkit-scroll-down)))
+      (kbd "C-u") 'evil-collection-xwidget-webkit-scroll-down-half-page)))
 
 (provide 'evil-collection-xwidget)
 ;;; evil-collection-xwidget.el ends here

--- a/modes/xwidget/evil-collection-xwidget.el
+++ b/modes/xwidget/evil-collection-xwidget.el
@@ -41,15 +41,15 @@
   "Scroll webkit up by half page."
   (interactive)
   (if (>= emacs-major-version 28)
-      (xwidget-webkit-scroll-up (evil-collection-xwidget-half-page-height))
-    (xwidget-webkit-scroll-up)))
+      (funcall 'xwidget-webkit-scroll-up (evil-collection-xwidget-half-page-height))
+    (funcall 'xwidget-webkit-scroll-up)))
 
 (defun evil-collection-xwidget-webkit-scroll-down-half-page ()
   "Scroll webkit down by half page."
   (interactive)
   (if (>= emacs-major-version 28)
-      (xwidget-webkit-scroll-down (evil-collection-xwidget-half-page-height))
-    (xwidget-webkit-scroll-down)))
+      (funcall 'xwidget-webkit-scroll-down (evil-collection-xwidget-half-page-height))
+    (funcall 'xwidget-webkit-scroll-down)))
 
 ;;;###autoload
 (defun evil-collection-xwidget-setup ()

--- a/modes/xwidget/evil-collection-xwidget.el
+++ b/modes/xwidget/evil-collection-xwidget.el
@@ -30,6 +30,8 @@
 (require 'xwidget)
 (require 'evil-collection)
 
+(declare-function xwidget-window-inside-pixel-height "xwidget")
+
 (defvar evil-collection-xwidget-maps '(xwidget-webkit-mode-map))
 
 (defmacro evil-collection-xwidget-half-page-height ()

--- a/modes/xwidget/evil-collection-xwidget.el
+++ b/modes/xwidget/evil-collection-xwidget.el
@@ -30,8 +30,6 @@
 (require 'xwidget)
 (require 'evil-collection)
 
-(declare-function xwidget-window-inside-pixel-height "xwidget")
-
 (defvar evil-collection-xwidget-maps '(xwidget-webkit-mode-map))
 
 (defmacro evil-collection-xwidget-half-page-height ()
@@ -41,12 +39,16 @@
 (defun evil-collection-xwidget-webkit-scroll-up-half-page ()
   "Scroll webkit up by half page."
   (interactive)
-  (xwidget-webkit-scroll-up (evil-collection-xwidget-half-page-height)))
+  (if (>= emacs-major-version 28)
+      (xwidget-webkit-scroll-up (evil-collection-xwidget-half-page-height))
+    (xwidget-webkit-scroll-up)))
 
 (defun evil-collection-xwidget-webkit-scroll-down-half-page ()
   "Scroll webkit down by half page."
   (interactive)
-  (xwidget-webkit-scroll-down (evil-collection-xwidget-half-page-height)))
+  (if (>= emacs-major-version 28)
+      (xwidget-webkit-scroll-down (evil-collection-xwidget-half-page-height))
+    (xwidget-webkit-scroll-down)))
 
 ;;;###autoload
 (defun evil-collection-xwidget-setup ()

--- a/modes/xwidget/evil-collection-xwidget.el
+++ b/modes/xwidget/evil-collection-xwidget.el
@@ -34,7 +34,8 @@
 
 (defmacro evil-collection-xwidget-half-page-height ()
   "Return Emacs xwidget half window height in pixel."
-  (/ (xwidget-window-inside-pixel-height (selected-window)) 2))
+  (let ((edges (window-inside-pixel-edges (selected-window))))
+    (/ (- (nth 3 edges) (nth 1 edges)) 2)))
 
 (defun evil-collection-xwidget-webkit-scroll-up-half-page ()
   "Scroll webkit up by half page."


### PR DESCRIPTION
-  `H` can browse the history
- `d` and `u` scroll half page up and down
- Add missing `A` and `RET` bindings