### PR TITLE
Fix C-u scroll in magit config

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -354,7 +354,7 @@ When this option is enabled, the stash popup is available on \"Z\"."
          (,states magit-mode-map "l"    evil-forward-char)))
 
      (when evil-want-C-u-scroll
-       `((,states magit-mode-map "C-u" evil-scroll-up)))
+       `((,states magit-mode-map "\C-u" evil-scroll-up)))
 
      (if evil-collection-magit-use-y-for-yank
          `((,states magit-mode-map "v"    evil-visual-line)


### PR DESCRIPTION
This little mistake broke the native magit `C` binding because the keybinding was now `C - u` rather than `C-u` ^^