### PR TITLE
Avoid binding escape to bury-buffer and quit-window

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -315,8 +315,7 @@ When this option is enabled, the stash popup is available on \"Z\"."
        (,states magit-mode-map ,(kbd "S-SPC") magit-diff-show-or-scroll-up   "SPC")
        (,states magit-mode-map ,(kbd "S-DEL") magit-diff-show-or-scroll-down "DEL")
 
-       ((,evil-collection-magit-state) magit-mode-map ,(kbd evil-toggle-key) evil-emacs-state)
-       ((,evil-collection-magit-state) magit-mode-map ,(kbd "<escape>") magit-mode-bury-buffer))
+       ((,evil-collection-magit-state) magit-mode-map ,(kbd evil-toggle-key) evil-emacs-state))
 
      (if (eq evil-search-module 'evil-search)
          `((,states magit-mode-map "/" evil-ex-search-forward)

--- a/modes/tetris/evil-collection-tetris.el
+++ b/modes/tetris/evil-collection-tetris.el
@@ -49,8 +49,7 @@
     "p" 'tetris-pause-game
     "q" 'quit-window
     "ZQ" 'quit-window
-    "ZZ" 'tetris-end-game
-    (kbd "<escape>") 'quit-window))
+    "ZZ" 'tetris-end-game))
 
 (provide 'evil-collection-tetris)
 ;;; evil-collection-tetris.el ends here


### PR DESCRIPTION
Escape usually means to:

1. Return to normal mode.
2. Abort the minibuffer.

By binding it to quit-window (or equivalent), hitting escape a few times to exit a (potentially recursive) minibuffer, etc. can cause buffers to vanish.

It's also:

1. Inconsistently applied. These are the only two modes that have escape bound this way.
2. Redundant with "q" (which is consistently applied).