### PR TITLE
Set readonly bindings for compilation mode

### DIFF
--- a/modes/compile/evil-collection-compile.el
+++ b/modes/compile/evil-collection-compile.el
@@ -37,6 +37,7 @@
 (defun evil-collection-compile-setup ()
   "Set up `evil' bindings for `compile'."
   (evil-set-initial-state 'compilation-mode 'normal)
+  (evil-collection-set-readonly-bindings 'compilation-mode-map)
 
   (dolist (keymap evil-collection-compile-maps)
 


### PR DESCRIPTION
Same idea that is used in, e.g., `evil-collection-help.el`.  In particular, it binds `q` to `quit-window`.
