### PR TITLE
Bind arrow keys in Doc View mode.

### DIFF
--- a/modes/doc-view/evil-collection-doc-view.el
+++ b/modes/doc-view/evil-collection-doc-view.el
@@ -38,13 +38,15 @@
   (evil-set-initial-state 'doc-view-mode 'normal)
   (evil-collection-define-key 'normal 'doc-view-mode-map
     "q" 'quit-window
+    [remap evil-next-line] 'doc-view-next-line-or-next-page
+    [remap evil-previous-line] 'doc-view-previous-line-or-previous-page
+    [remap evil-backward-char] 'image-backward-hscroll
+    [remap evil-forward-char] 'image-forward-hscroll
     (kbd "C-j") 'doc-view-next-page
     (kbd "C-k") 'doc-view-previous-page
     "gj" 'doc-view-next-page
     "gk" 'doc-view-previous-page
     (kbd "C-d") 'forward-page
-    "j" 'doc-view-next-line-or-next-page
-    "k" 'doc-view-previous-line-or-previous-page
     (kbd "SPC") 'doc-view-scroll-up-or-next-page
     (kbd "DEL") 'doc-view-scroll-down-or-previous-page
     (kbd "S-SPC") 'doc-view-scroll-down-or-previous-page

--- a/modes/image/evil-collection-image.el
+++ b/modes/image/evil-collection-image.el
@@ -41,10 +41,10 @@
     ;; motion
     "gg" 'image-bob
     "G" 'image-eob
-    "h" 'image-backward-hscroll
-    "l" 'image-forward-hscroll
-    "j" 'image-next-line
-    "k" 'image-previous-line
+    [remap evil-forward-char] 'image-forward-hscroll
+    [remap evil-backward-char] 'image-backward-hscroll
+    [remap evil-next-line] 'image-next-line
+    [remap evil-previous-line] 'image-previous-line
     "0" 'image-bol
     "^" 'image-bol
     "$" 'image-eol


### PR DESCRIPTION
I found that these keys were bound to the normal character/line Evil motions in normal state. This changes them to have the same bindings that they have in the Emacs state.