### PR TITLE
unimpaired: add vanilla next-error navigation

### DIFF
--- a/modes/unimpaired/evil-collection-unimpaired.el
+++ b/modes/unimpaired/evil-collection-unimpaired.el
@@ -68,7 +68,7 @@
          (fboundp 'flymake-goto-next-error))
     (flymake-goto-next-error count))
    (:default
-    (message "No linting modes are on."))))
+    (next-error count))))
 
 (evil-define-motion evil-collection-unimpaired-previous-error (count)
   "Go to previous error."
@@ -89,7 +89,7 @@
    ((bound-and-true-p flymake-mode)
     (message "flymake unsupported."))
    (:default
-    (message "No linting modes are on."))))
+    (first-error))))
 
 (evil-define-motion evil-collection-unimpaired-last-error ()
   "Go to the last error."
@@ -101,7 +101,7 @@
    ((bound-and-true-p flymake-mode)
     (message "flymake unsupported."))
    (:default
-    (message "No linting modes are on."))))
+    (message "No linting modes are on; vanilla errors unsupported."))))
 
 (defconst evil-collection-unimpaired--SCM-conflict-marker "^\\(@@@ .* @@@\\|[<=>]\\{7\\}\\)"
   "A regexp to match SCM conflict marker.")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs comes with built-in error jumping commands:
`(next-error)` and `(first-error)` are the Emacs equivalents of `:cnext` and `:cfirst` in Vim, which jump between errors in the `*compilation*` buffer, among other things.

They can move between buffers, so the behaviour might be unpredictable.

### Direct link to the package repository

https://github.com/aidan-hall/evil-collection

### Checklist

<!-- Please confirm with `x`: -->
- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy.

<!-- After submitting, please fix any problems the CI reports. -->
