### PR TITLE
magit/forge: restore defaults bindings in magit-branch transient

### DIFF
--- a/modes/forge/evil-collection-forge.el
+++ b/modes/forge/evil-collection-forge.el
@@ -94,9 +94,9 @@ To suppress this message you can set this variable to nil in your init.el file."
   (transient-append-suffix 'magit-pull "n"
     '("N" "forge notifications" forge-pull-notifications))
   (transient-append-suffix 'magit-branch "w"
-    '("n" "pull-request" forge-checkout-pullreq))
+    '("f" "pull-request" forge-checkout-pullreq))
   (transient-append-suffix 'magit-branch "W"
-    '("N" "from pull-request" forge-branch-pullreq))
+    '("F" "from pull-request" forge-branch-pullreq))
   (transient-append-suffix 'magit-worktree "c"
     '("n" "pull-request worktree" forge-checkout-worktree))
   (transient-append-suffix 'magit-status-jump "w"


### PR DESCRIPTION
With Magit and Forge defaults bindings, the "n" key allows you to create a new branch (without checkout/branch change) in "magit-branch" transient window. Evil-collection-forge overrides this binding (the "n" key is used to checkout a pull-request) . So there is no more binding to create a new branch (without checkout) as we can see in this screenshot (third column):
![forge_before](https://user-images.githubusercontent.com/17704127/154164212-e311e833-5ca0-484b-a96b-57b537416282.png)

This PR restores defaults bindings in "magit-branch" transient window:
![forge_after](https://user-images.githubusercontent.com/17704127/154164527-d4392f9e-70e3-433d-b2d1-ace68e95fb23.png)

