### PR TITLE
Bind other Selectrum commands.

### DIFF
--- a/modes/selectrum/evil-collection-selectrum.el
+++ b/modes/selectrum/evil-collection-selectrum.el
@@ -53,7 +53,12 @@
 
     (evil-collection-define-key 'normal 'selectrum-minibuffer-map
       (kbd "j") 'selectrum-next-candidate
-      (kbd "k") 'selectrum-previous-candidate)
+      (kbd "k") 'selectrum-previous-candidate
+      (kbd "gj") 'selectrum-next-group
+      (kbd "gk") 'selectrum-previous-group
+      (kbd "G") 'selectrum-goto-end
+      (kbd "gg") 'selectrum-goto-beginning
+      (kbd "gy") 'selectrum-kill-ring-save)
 
     (when evil-want-C-u-scroll
       (evil-collection-define-key '(insert normal) 'selectrum-minibuffer-map


### PR DESCRIPTION
This adds bindings for the following commands:

| Command                    | Binding | 
|----------------------------|---------|
| `selectrum-next-group`     | `gj`    |
| `selectrum-next-group`     | `gj`    |
| `selectrum-previous-group` | `gk`    |
| `selectrum-goto-end`       | `gg`    |
| `selectrum-goto-beginning` | `G`     |
| `selectrum-kill-ring-save` | `gy`    |
