### PR TITLE
ebib: change mapping for "y" in ebib-entry-mode.

### DIFF
--- a/modes/ebib/evil-collection-ebib.el
+++ b/modes/ebib/evil-collection-ebib.el
@@ -69,7 +69,7 @@
     "j" 'ebib-next-field
     "k" 'ebib-prev-field
     "p" 'ebib-yank-field-contents
-    "y" 'ebib-copy-field-contents
+    "y" 'ebib-copy-current-field-contents
     "ZZ" 'ebib-quit-entry-buffer
     "ZQ" 'ebib-quit-entry-buffer))
 


### PR DESCRIPTION
Change mapping for "y" in ebib-entry-mode to "ebib-copy-current-field-contents" instead of "ebib-copy-field-contents" since the latter is not a command.
