### PR TITLE
Delay running `evil-collection-setup-hook` for modes like eshell (#602)

### DIFF
--- a/modes/eshell/evil-collection-eshell.el
+++ b/modes/eshell/evil-collection-eshell.el
@@ -137,7 +137,12 @@ appropriate in some cases like terminals."
     "gk" 'eshell-previous-prompt
     "gj" 'eshell-next-prompt
     "0" 'eshell-bol
-    "^" 'eshell-bol))
+    "^" 'eshell-bol)
+
+  (evil-normalize-keymaps)
+  (unless evil-collection-always-run-setup-hook-after-load
+    (run-hook-with-args
+     'evil-collection-setup-hook 'eshell evil-collection-eshell-maps)))
 
 ;; TODO: Compare this setup procedure with evil-ediff.
 ;;;###autoload


### PR DESCRIPTION
@noctuid Would love your thoughts on this. Think introducing this abstraction for these wonky modes with really late keymap initializations is good considering the hook's original purpose was to allow setting these types of binds after the bind exists is and already mapped.

This shouldn't affect how user's use the hooks as it'll get called at some point..

@condy0919 