### PR TITLE
Add bindings for the new help-mode commands

### DIFF
--- a/modes/help/evil-collection-help.el
+++ b/modes/help/evil-collection-help.el
@@ -68,7 +68,13 @@
     "gr" 'revert-buffer
     "<" 'help-go-back
     ">" 'help-go-forward
-    "r" 'help-follow))
+    "r" 'help-follow)
+
+  (when (>= emacs-major-version 28)
+    (evil-collection-define-key 'normal 'help-mode-map
+      "s" 'help-view-source
+      "i" 'help-goto-info
+      "c" 'help-customize)))
 
 (provide 'evil-collection-help)
 ;;; evil-collection-help.el ends here


### PR DESCRIPTION
This pull request adds keybindings for the new help-mode commands introduced in Emacs 28. See also: https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS.28#n558
