### PR TITLE
Add "g," as a keybinding for `Info-index-next'

### DIFF
--- a/modes/info/evil-collection-info.el
+++ b/modes/info/evil-collection-info.el
@@ -96,6 +96,8 @@
     "gj" 'Info-next
     "gk" 'Info-prev
 
+    "g," 'Info-index-next
+
     "g?" 'Info-summary)
 
   ;; yu, Like eww.


### PR DESCRIPTION
I have noticed that there is no equivalent to `Info-index-next` in evil-collection-Info. In vanilla emacs, it is bound to `,`. I believe that `g,` is the most logical evil-equivalent.  