### PR TITLE
vterm: use ^ for jumping at the beginning of the command but after prompt

### DIFF
--- a/modes/vterm/evil-collection-vterm.el
+++ b/modes/vterm/evil-collection-vterm.el
@@ -67,6 +67,17 @@ also uses `evil-mode'."
                        "vterm"
                      "emacs"))))
 
+(declare-function vterm-cursor-in-command-buffer-p "vterm")
+(declare-function vterm-beginning-of-line "vterm")
+
+(evil-define-motion evil-collection-vterm-first-non-blank ()
+  "Move the cursor to the first non-blank character
+after the prompt."
+  :type exclusive
+  (if (vterm-cursor-in-command-buffer-p (point))
+      (vterm-beginning-of-line)
+    (evil-first-non-blank)))
+
 (defun evil-collection-vterm-insert ()
   "Insert character before cursor."
   (interactive)
@@ -232,6 +243,7 @@ Save in REGISTER or in the kill-ring with YANK-HANDLER."
     "D" 'evil-collection-vterm-delete-line
     "x" 'evil-collection-vterm-delete-backward-char
     (kbd "RET") 'vterm-send-return
+    "^" 'evil-collection-vterm-first-non-blank
     "i" 'evil-collection-vterm-insert
     "I" 'evil-collection-vterm-insert-line
     "u" 'vterm-undo


### PR DESCRIPTION
We have `0` for jumping at the very first character of the current
line and `^` for jumping to the non-blank character. It is useful to
keep this distinction in `vterm` buffers. However, it doesn't make
much sense in the command part. Because we have a prompt, both of the
commands jump to the very first character. I think it would be more
useful to change `^` to jump to the first non-blank character after
the prompt.