### PR TITLE
compile: bind TAB to compilation-next-error

### DIFF
--- a/modes/compile/evil-collection-compile.el
+++ b/modes/compile/evil-collection-compile.el
@@ -50,6 +50,9 @@
       "go" 'compilation-display-error
       (kbd "S-<return>") 'compilation-display-error
 
+      (kbd "TAB") 'compilation-next-error
+      (kbd "S-TAB") 'compilation-previous-error
+
       "gj" 'compilation-next-error
       "gk" 'compilation-previous-error
       (kbd "C-j") 'compilation-next-error


### PR DESCRIPTION
Currently, it's bound to evil-jump-forward, which isn't useful in compile-mode.

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
