### PR TITLE
vterm: when deleting command with `dd`, reset cursor after prompt

### DIFF
--- a/modes/vterm/evil-collection-vterm.el
+++ b/modes/vterm/evil-collection-vterm.el
@@ -112,7 +112,7 @@ after the prompt."
 (declare-function vterm-reset-cursor-point "vterm")
 
 (evil-define-operator evil-collection-vterm-delete (beg end type register yank-handler)
-  "Modification of evil-delete to work in vterm buffer. 
+  "Modification of evil-delete to work in vterm buffer.
 Delete text from BEG to END with TYPE.
 Save in REGISTER or in the kill-ring with YANK-HANDLER."
   (interactive "<R><x><y>")

--- a/modes/vterm/evil-collection-vterm.el
+++ b/modes/vterm/evil-collection-vterm.el
@@ -109,6 +109,8 @@ after the prompt."
   (vterm-goto-char (+ 1 (point)))
   (call-interactively #'vterm-yank arg))
 
+(declare-function vterm-reset-cursor-point "vterm")
+
 (evil-define-operator evil-collection-vterm-delete (beg end type register yank-handler)
   "Modification of evil-delete to work in vterm buffer. 
 Delete text from BEG to END with TYPE.
@@ -138,7 +140,7 @@ Save in REGISTER or in the kill-ring with YANK-HANDLER."
     ;; place cursor on beginning of line
     (when (and (called-interactively-p 'any)
                (eq type 'line))
-      (evil-first-non-blank))))
+      (vterm-reset-cursor-point))))
 
 (evil-define-operator evil-collection-vterm-delete-backward-char (beg end type register)
   "Delete previous character."


### PR DESCRIPTION
The original `evil-first-non-blank` isn't usable because the beginning
of the prompt is the first non-blank character. Strangely enough,
`vterm-beginning-of-line` didn't work either.
