### PR TITLE
add ebuku to supported modes

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -172,6 +172,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     doc-view
     docker
     ebib
+    ebuku
     edbi
     edebug
     ediff


### PR DESCRIPTION
### Brief summary of what the package does

NA


### Direct link to the package repository

NA

### Checklist

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`


### Content

Currently `ebuku`'s keybinding is already in [modes](https://github.com/emacs-evil/evil-collection/tree/master/modes/ebuku), however, it's not in the `el` file, so users needs to manually trigger it either appending it to `evil-collection-mode-list` before init or directly do `(evil-collection-init 'ebuku)`.
