### PR TITLE
Bind `H` to `realgud:cmd-until-here`

### DIFF
--- a/modes/realgud/evil-collection-realgud.el
+++ b/modes/realgud/evil-collection-realgud.el
@@ -81,7 +81,7 @@
     "e" 'realgud:cmd-eval-dwim
     "E" 'realgud:cmd-eval-at-point
     "U" 'realgud:cmd-until
-    "H" 'realgud:cmd-until
+    "H" 'realgud:cmd-until-here
     [mouse-2] 'realgud:tooltip-eval
     [left-fringe mouse-1] 'realgud-cmds--mouse-add-remove-bp
     [left-margin mouse-1] 'realgud-cmds--mouse-add-remove-bp


### PR DESCRIPTION
As the title sais.
Before both `H` and `U` both where bound to the command `realgud:cmd-until` and there was no key for 
the function `realgud:cmd-until-here`