### PR TITLE
dired: separate definition of dired-x bindings

### DIFF
--- a/modes/dired/evil-collection-dired.el
+++ b/modes/dired/evil-collection-dired.el
@@ -103,9 +103,6 @@
     "*/" 'dired-mark-directories
     "*@" 'dired-mark-symlinks
     "*%" 'dired-mark-files-regexp
-    "*(" 'dired-mark-sexp
-    "*." 'dired-mark-extension
-    "*O" 'dired-mark-omitted
     "*c" 'dired-change-marks
     "*s" 'dired-mark-subdir-files
     "*m" 'dired-mark
@@ -192,6 +189,13 @@
     ";v" 'epa-dired-do-verify
     ";s" 'epa-dired-do-sign
     ";e" 'epa-dired-do-encrypt)
+
+  ;; dired-x commands
+  (with-eval-after-load 'dired-x
+    (evil-collection-define-key 'normal 'dired-mode-map
+      "*(" 'dired-mark-sexp
+      "*." 'dired-mark-extension
+      "*O" 'dired-mark-omitted))
 
   ;; dired-narrow commands
   (with-eval-after-load 'dired-narrow


### PR DESCRIPTION
The following 3 commands are not defined in `dired.el` and are not available until `dired-x.el` is loaded:
- `dired-mark-sexp`
- `dired-mark-extension`
- `dired-mark-omitted`