### PR TITLE
[mpdel] Modify song seek keybindings from three to two keys

### DIFF
--- a/modes/mpdel/evil-collection-mpdel.el
+++ b/modes/mpdel/evil-collection-mpdel.el
@@ -76,12 +76,12 @@
     "I"  'mpdel-song-play
     "q"  'mpdel-song-quit-window
 
-    "g-s" 'mpdel-song-small-increment
-    "g-n" 'mpdel-song-normal-increment
-    "g-l" 'mpdel-song-large-increment
-    "g+s" 'mpdel-song-small-decrement
-    "g+n" 'mpdel-song-normal-decrement
-    "g+l" 'mpdel-song-large-decrement
+    ">s" 'mpdel-song-small-increment
+    ">n" 'mpdel-song-normal-increment
+    ">l" 'mpdel-song-large-increment
+    "<s" 'mpdel-song-small-decrement
+    "<n" 'mpdel-song-normal-decrement
+    "<l" 'mpdel-song-large-decrement
 
     "gl" 'mpdel-playlist-open
     "("  'mpdel-playlist-move-up


### PR DESCRIPTION

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [X] byte-compiles cleanly
- [X] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [X] define `evil-collection-mpc-setup` with `defun`
- [X] define `evil-collection-mpc-mode-maps` with `defconst`
- [X] All functions should start with `evil-collection-mpc-`

