### PR TITLE
Correct cursor position when evil-append in vterm

### DIFF
--- a/modes/vterm/evil-collection-vterm.el
+++ b/modes/vterm/evil-collection-vterm.el
@@ -93,7 +93,7 @@ after the prompt."
 (defun evil-collection-vterm-append ()
   "Append character after cursor."
   (interactive)
-  (vterm-goto-char (1+ (point)))
+  (vterm-goto-char (point))
   (call-interactively #'evil-append))
 
 (defun evil-collection-vterm-append-line ()


### PR DESCRIPTION
vterm: currently, typing `a` in normal mode moves the cursor 2 characters to the right. 

We either (+ 1 (point)) and call evil-insert or evil-append at (point).