### PR TITLE
Use `C-n` and `C-p` for navigation in xref

### DIFF
--- a/modes/xref/evil-collection-xref.el
+++ b/modes/xref/evil-collection-xref.el
@@ -43,6 +43,8 @@
     "gk" 'xref-prev-line
     (kbd "C-j") 'xref-next-line
     (kbd "C-k") 'xref-prev-line
+    (kbd "C-n") 'xref-next-line
+    (kbd "C-p") 'xref-prev-line
     "]]" 'xref-next-line
     "[[" 'xref-prev-line
     "r" 'xref-query-replace-in-results


### PR DESCRIPTION
This matches how the keys behave in other modes. Otherwise they are bound to `evil-paste-pop` which isn't valid in xref buffers.