### PR TITLE
snake: initial support

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -292,6 +292,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     simple-mpc
     slime
     sly
+    snake
     speedbar
     ,@(when (>= emacs-major-version 27) '(tab-bar))
     tablist

--- a/modes/snake/evil-collection-snake.el
+++ b/modes/snake/evil-collection-snake.el
@@ -1,0 +1,43 @@
+;;; evil-collection-snake.el --- Bindings for `snake' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen
+;; Copyright (C) 2022 Farzin Firouzi
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Bindings for `snake'.
+
+;;; Code:
+(require 'evil-collection)
+
+(defconst evil-collection-snake-maps '(snake-mode-map))
+
+;;;###autoload
+(defun evil-collection-snake-setup ()
+  "Set up `evil' bindings for `snake'."
+  (evil-set-initial-state 'snake-mode 'normal)
+  (evil-collection-define-key 'normal 'snake-mode-map
+    "h" 'snake-move-left
+    "l" 'snake-move-right
+    "j" 'snake-move-down
+    "k" 'snake-move-up
+    "gr" 'snake-start-game
+    "p" 'snake-pause-game
+    "q" 'quit-window
+    "ZQ" 'quit-window
+    "ZZ" 'snake-end-game))
+
+(provide 'evil-collection-snake)
+;;; evil-collection-snake.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

Adds support for `snake` game

### Direct link to the package repository

https://github.com/wickedjargon/evil-collection

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
