### PR TITLE
Added blutooth-mode bindings

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -151,6 +151,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     atomic-chrome
     auto-package-update
     beginend
+    bluetooth
     bm
     bookmark
     (buff-menu "buff-menu")

--- a/modes/bluetooth/evil-collection-bluetooth.el
+++ b/modes/bluetooth/evil-collection-bluetooth.el
@@ -1,0 +1,59 @@
+;;; evil-collection-bluetooth.el --- Bindings for `bluetooth' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022 Arian Dehghani
+
+;; Author: Arian Dehghani <arianxdehghani@gmail.com>
+;; Maintainer: Arian Dehghani <arianxdehghani@gmail.com>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "27.1"))
+;; Keywords: evil, emacs, tools, blutooth
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for `bluetooth'.
+
+;;; Code:
+(require 'evil-collection)
+(require 'bluetooth nil t)
+
+(defvar bluetooth-mode-map)
+
+(defconst evil-collection-bluetooth-maps '(bluetooth-mode-map))
+
+;;;###autoload
+(defun evil-collection-bluetooth-setup ()
+  "Set up `evil' bindings for `bluetooth'."
+  (evil-collection-set-readonly-bindings 'bluetooth-mode-map)
+  (evil-collection-define-key 'normal 'bluetooth-mode-map
+    "c" 'bluetooth-connect
+    "d" 'bluetooth-disconnect
+    "b" 'bluetooth-toggle-blocked
+    "t" 'bluetooth-toggle-trusted
+    "a" 'bluetooth-set-alias
+    "r" 'bluetooth-start-discovery
+    "R" 'bluetooth-stop-discovery
+    "s" 'bluetooth-toggle-powered
+    "P" 'bluetooth-pair
+    "D" 'bluetooth-toggle-discoverable
+    "x" 'bluetooth-toggle-pairable
+    "i" 'bluetooth-show-device-info
+    "A" 'bluetooth-show-adapter-info
+    "K" 'bluetooth-remove-device
+    "<" 'bluetooth-beginning-of-list
+    ">" 'bluetooth-end-of-list))
+
+(provide 'evil-collection-bluetooth)
+;;; evil-collection-bluetooth.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

Added support for [bluetooth](https://gitlab.com/rstocker/emacs-bluetooth) by redefining the keys ignored by `tabulated-list`

### Direct link to the package repository

https://github.com/arian-d/evil-collection

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
