### PR TITLE
Declare some navigation commands to be non-repeatable

### DIFF
--- a/modes/consult/evil-collection-consult.el
+++ b/modes/consult/evil-collection-consult.el
@@ -79,14 +79,14 @@ as defined in `evil-collection-consult--evil-mark-ring'."
   (let* ((candidates)
          (current-buf (current-buffer)))
     (save-excursion
-      (dolist (marker (or markers (evil-collection-consult--evil-mark-ring)))
-        (let ((pos (marker-position (cdr marker)))
-              (buf (marker-buffer (cdr marker))))
+      (pcase-dolist (`(,char . ,marker) (or markers (evil-collection-consult--evil-mark-ring)))
+        (let ((pos (marker-position marker))
+              (buf (marker-buffer marker)))
           (when (and (eq buf current-buf)
                      (consult--in-range-p pos))
             (goto-char pos)
             (push (consult--location-candidate
-                   (format "%s: %s" (char-to-string (car marker)) (consult--line-with-cursor (cdr marker))) (cdr marker)
+                   (format "%s: %s" (char-to-string char) (consult--line-with-cursor marker)) marker
                    (line-number-at-pos pos consult-line-numbers-widen))
                   candidates)))))
     (nreverse (delete-dups candidates))))

--- a/modes/consult/evil-collection-consult.el
+++ b/modes/consult/evil-collection-consult.el
@@ -52,12 +52,13 @@
 
 (defun evil-collection-consult-set-bindings ()
   "Set the bindings."
-  (evil-set-command-property 'consult-outline :jump t)
-  (evil-set-command-property 'consult-mark :jump t)
-  (evil-set-command-property 'consult-global-mark :jump t)
-  (evil-set-command-property 'consult-imenu :jump t)
-  (evil-set-command-property 'consult-org-heading :jump t)
-  (evil-set-command-property 'consult-line :jump t))
+  (dolist (cmd '(consult-outline
+                 consult-mark
+                 consult-global-mark
+                 consult-imenu
+                 consult-org-heading
+                 consult-line))
+    (evil-set-command-property cmd :jump t)))
 
 (defun evil-collection-consult--evil-mark-ring ()
   "Return alist of char & marker for evil markers in current buffer."

--- a/modes/consult/evil-collection-consult.el
+++ b/modes/consult/evil-collection-consult.el
@@ -58,6 +58,7 @@
                  consult-imenu
                  consult-org-heading
                  consult-line))
+    (evil-declare-not-repeat cmd)
     (evil-set-command-property cmd :jump t)))
 
 (defun evil-collection-consult--evil-mark-ring ()

--- a/modes/imenu/evil-collection-imenu.el
+++ b/modes/imenu/evil-collection-imenu.el
@@ -32,6 +32,7 @@
 ;;;###autoload
 (defun evil-collection-imenu-setup ()
   "Set up Evil integration for `imenu'."
+  (evil-declare-not-repeat 'imenu)
   (evil-add-command-properties 'imenu :jump t))
 
 (provide 'evil-collection-imenu)


### PR DESCRIPTION
These commands should be repeated via `vertico-repeat` or `ivy-resume`. We prefer to use `evil-repeat` for commands that modify buffer contents.