### PR TITLE
mu4e: delete the redundant keybinding

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -54,7 +54,7 @@
 ;; | Skip duplicates                 | zd        |             |
 ;; | Show log                        | gl        |             |
 ;; | Select other view               | gv        |             |
-;; | Save attachement(s)             | p         | P           |
+;; | Save attachement(s)             | p         |             |
 ;; | Save url                        | yu        |             |
 ;; | Go to url                       | gx        |             |
 ;; | Fetch url                       | gX        |             |
@@ -220,7 +220,6 @@ with older release versions of `mu4e.'"
      "cf" mu4e-compose-forward
      "cr" mu4e-compose-reply
      "p" mu4e-view-save-attachments
-     "P" mu4e-view-save-attachments
      "O" mu4e-headers-change-sorting
      "A" mu4e-view-mime-part-action ; Since 1.6, uses gnus view by default
      "a" mu4e-view-action


### PR DESCRIPTION
delete the redundant keybinding as discussed in https://github.com/emacs-evil/evil-collection/pull/660#issuecomment-1188723037