### PR TITLE
mu4e: remove the inaccurate description

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -310,7 +310,7 @@ with older release versions of `mu4e.'"
   "Define the evil-mu4e Misc region."
   (concat
    (evil-collection-mu4e--main-action-str "\t* [;]Switch focus\n" 'mu4e-context-switch)
-   (evil-collection-mu4e--main-action-str "\t* [u]pdate email & database (Alternatively: gr)\n"
+   (evil-collection-mu4e--main-action-str "\t* [u]pdate email & database\n"
                                           'mu4e-update-mail-and-index)
 
    ;; show the queue functions if `smtpmail-queue-dir' is defined


### PR DESCRIPTION
-------

`revert-buffer-function` is set to `mu4e--main-view-real` in mu4e main mode. It's not the same as `mu4e-update-mail-and-index`(u).