### PR TITLE
pdf: Add binds for `pdf-history-forward/backward`

### DIFF
--- a/modes/pdf/evil-collection-pdf.el
+++ b/modes/pdf/evil-collection-pdf.el
@@ -30,8 +30,10 @@
 (require 'evil-collection)
 (require 'pdf-tools nil t)
 (require 'pdf-view nil t)
+(require 'pdf-history nil t)
 
 (defconst evil-collection-pdf-maps '(pdf-view-mode-map
+                                     pdf-history-minor-mode-map
                                      pdf-outline-buffer-mode-map
                                      pdf-occur-buffer-mode-map))
 
@@ -40,12 +42,11 @@
 (declare-function pdf-view-goto-page "pdf-view")
 (declare-function pdf-view-previous-line-or-previous-page "pdf-view")
 (declare-function pdf-view-next-line-or-next-page "pdf-view")
+(declare-function pdf-history-forward "pdf-history")
+(declare-function pdf-history-backward "pdf-history")
 
 (defvar pdf-view-mode-map)
-(defvar pdf-outline-buffer-mode-map)
-(defvar pdf-occur-buffer-mode-map)
-
-(defvar pdf-view-mode-map)
+(defvar pdf-history-minor-mode-map)
 (defvar pdf-outline-buffer-mode-map)
 (defvar pdf-occur-buffer-mode-map)
 
@@ -94,6 +95,20 @@ Consider COUNT."
       (pdf-view-first-page)
       (image-bob)
       (image-set-window-hscroll hscroll))))
+
+(defun evil-collection-pdf-jump-forward (&optional count)
+  "Wrap `pdf-history-forward' with `evil'.
+
+Consider COUNT."
+  (interactive "P")
+  (pdf-history-forward (or count 1)))
+
+(defun evil-collection-pdf-jump-backward (&optional count)
+  "Wrap `pdf-history-backward' with `evil'.
+
+Consider COUNT."
+  (interactive "P")
+  (pdf-history-backward (or count 1)))
 
 ;;;###autoload
 (defun evil-collection-pdf-setup ()
@@ -194,6 +209,13 @@ Consider COUNT."
 
   (evil-collection-define-key 'visual 'pdf-view-mode-map
     "y" 'pdf-view-kill-ring-save)
+
+  (evil-collection-inhibit-insert-state 'pdf-history-minor-mode-map)
+  (evil-set-initial-state 'pdf-history-minor-mode 'normal)
+  (evil-collection-define-key 'normal 'pdf-history-minor-mode-map
+    ;; history forward / backward
+    (kbd "C-i") 'evil-collection-pdf-jump-forward
+    (kbd "C-o") 'evil-collection-pdf-jump-backward)
 
   (evil-collection-inhibit-insert-state 'pdf-outline-buffer-mode-map)
   (evil-set-initial-state 'pdf-outline-buffer-mode 'normal)


### PR DESCRIPTION
### Brief summary of what the package does

`pdf-tools` has functions for navigating in jump history. This PR simply adds 
standard bindings to these functions. The prefix counters are also supported.

### Direct link to the package repository

https://github.com/vedang/pdf-tools

### Checklist

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`