### PR TITLE
Add bindings for crdt.el's menu modes

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -164,6 +164,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     compile
     consult
     corfu
+    crdt
     (custom cus-edit)
     cus-theme
     dashboard

--- a/modes/crdt/evil-collection-crdt.el
+++ b/modes/crdt/evil-collection-crdt.el
@@ -1,0 +1,57 @@
+;;; evil-collection-crdt.el --- Bindings for `crdt' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022 Arte Ebrahimi and Jonathan Ming
+
+;; Authors: Arte Ebrahimi <arteebrahimi@gmail.com> and Jonathan Ming <jming422@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.2
+;; Package-Requires: ((emacs "27.1"))
+;; Keywords: evil, emacs, convenience, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for crdt.
+
+;;; Code:
+(require 'evil-collection)
+(require 'crdt nil t)
+
+(defvar crdt-mode-map)
+(defconst evil-collection-crdt-maps
+  '(crdt-buffer-menu-mode-map crdt-session-menu-mode-map crdt-user-menu-mode-map crdt-read-settings-map))
+
+(defun evil-collection-crdt-setup ()
+  "Set up `evil' bindings for crdt."
+  (evil-collection-define-key 'normal 'crdt-buffer-menu-mode-map
+    (kbd "RET") 'crdt-switch-to-buffer-other-window
+    "x" 'crdt-stop-share-buffer)
+
+  (evil-collection-define-key 'normal 'crdt-session-menu-mode-map
+    (kbd "RET") 'crdt-list-buffers
+    "x" 'crdt--stop-session)
+
+  (evil-collection-define-key 'normal 'crdt-user-menu-mode-map
+    (kbd "RET") 'crdt-goto-user
+    "x" 'crdt-kill-user
+    "f" 'crdt-follow-user)
+
+  (evil-collection-define-key 'normal 'crdt-read-settings-map
+    (kbd "RET") 'exit-recursive-edit
+    "q" 'abort-recursive-edit
+    "ZZ" 'exit-recursive-edit))
+
+(provide 'evil-collection-crdt)
+;;; evil-collection-crdt.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

Adds normal state bindings for [crdt.el](https://code.librehq.com/qhong/crdt.el)'s menu modes. These modes have default bindings which work as expected when in insert state, but not in normal state. This PR adds bindings that add expected functionality while in normal state, which is these menu buffers' default. The `RET` bindings in particular are very helpful; the others are mostly icing on the cake.

### Direct link to the package repository

https://code.librehq.com/qhong/crdt.el

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `crdt` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-crdt)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-crdt-setup` with `defun`
- [x] define `evil-collection-crdt-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-crdt-`

<!-- After submitting, please fix any problems the CI reports. -->
