### PR TITLE
eglot: add binding for xref-find-definitions-other-frame

### DIFF
--- a/modes/eglot/evil-collection-eglot.el
+++ b/modes/eglot/evil-collection-eglot.el
@@ -36,6 +36,8 @@
   "Set up `evil' bindings for `eglot'."
   (evil-collection-define-key 'normal 'eglot-mode-map
     "gd" 'xref-find-definitions
+    "gD" 'xref-find-definitions-other-window
+    "g5" 'xref-find-definitions-other-frame
     (kbd "C-t") 'xref-pop-marker-stack
     "K" 'eldoc-doc-buffer)
 


### PR DESCRIPTION
### Brief summary of what the package does

This adds a binding to eglot for xref-find-definitions-other-frame