### PR TITLE
shortdoc: (S-)?tab to navigate buttons

### DIFF
--- a/modes/shortdoc/evil-collection-shortdoc.el
+++ b/modes/shortdoc/evil-collection-shortdoc.el
@@ -38,6 +38,8 @@
   "Set up `evil' bindings for `shortdoc'."
   (evil-set-initial-state 'shortdoc-mode 'normal)
   (evil-collection-define-key 'normal 'shortdoc-mode-map
+    (kbd "<tab>") 'forward-button
+    (kbd "<backtab>") 'backward-button
     (kbd "C-k") 'shortdoc-previous
     (kbd "C-j") 'shortdoc-next
     "[[" 'shortdoc-previous-section


### PR DESCRIPTION
Just like help buffers.

### Brief summary of what the package does

Bind `TAB` and `S-TAB` to `forward/backward-button` in shortdoc buffers.

### Direct link to the package repository

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
