### PR TITLE
Bring `arc-mode` bindings closer to defaults

### DIFF
--- a/modes/arc-mode/evil-collection-arc-mode.el
+++ b/modes/arc-mode/evil-collection-arc-mode.el
@@ -58,9 +58,10 @@
     "d" 'archive-flag-deleted
     "r" 'archive-rename-entry
     "x" 'archive-expunge
+    "C" 'archive-copy-file
     "M" 'archive-chmod-entry
+    "O" 'archive-chown-entry
     "P" 'archive-chgrp-entry
-    "C" 'archive-chown-entry
 
     ;; refresh
     "gr" 'revert-buffer


### PR DESCRIPTION
This commit changes the normal-mode binding for `C` to `archive-copy-file` (which extracts, or copies, the file under cursor to the filesystem) from `archive-chown-entry` (which changes the file owner), and adds a new binding for the latter on `O`.

Understandably, `O` has a pre-existing meaning in Vi for normal mode, but is quite useless in `arc-mode`, since these buffers are declared read-only by default, and having them be read-write does nothing.

The intention behind this commit providing a straightforward way for file extraction to happen in `arc-mode` under Evil, a (presumably) common operation. Additionally, these new bindings now mirror those used in Emacs for `arc-mode`, as well as Emacs and Evil bindings for `tar-mode`; these improvements are likely worth the user-facing change made.

### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/your/awesome_package

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [ ] byte-compiles cleanly
- [ ] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
