### PR TITLE
Support new `python-ts-mode`

### DIFF
--- a/modes/python/evil-collection-python.el
+++ b/modes/python/evil-collection-python.el
@@ -30,7 +30,9 @@
 (require 'evil-collection)
 (require 'python)
 
-(defconst evil-collection-python-maps '(python-mode-map))
+(defconst evil-collection-python-maps '(python-mode-map
+                                        python-ts-mode-map
+                                        python-base-mode-map))
 
 (defun evil-collection-python-set-evil-shift-width ()
   "Set `evil-shift-width' according to `python-indent-offset'."
@@ -39,10 +41,12 @@
 ;;;###autoload
 (defun evil-collection-python-setup ()
   "Set up `evil' bindings for `python'."
-  (add-hook 'python-mode-hook #'evil-collection-python-set-evil-shift-width)
+  (dolist (hook '(python-mode-hook python-ts-mode-hook))
+    (add-hook hook #'evil-collection-python-set-evil-shift-width))
 
-  (evil-collection-define-key 'normal 'python-mode-map
-    "gz" 'python-shell-switch-to-shell))
+  (dolist (kmap evil-collection-python-maps)
+    (evil-collection-define-key 'normal kmap
+      "gz" 'python-shell-switch-to-shell)))
 
 (provide 'evil-collection-python)
 ;;; evil-collection-python.el ends here


### PR DESCRIPTION
## Support Emacs 29 `python-ts-mode` (tree-sitter  mode for python)

The yet unreleased Emacs 29 can be compiled with built-in tree sitter support, and includes several variants of programming language major modes which do font-locking via tree-sitter. Usually they end with `...-ts-mode` and are defined in the same elisp package as the original major mode. They have separate keymaps and hooks, so to support them those would also need to be used.

I looked supporting `python-ts-mode` via `evil-collection-python-setup`. Actually, the new `python` package also defines a new `python-base-mode` from which both `python-mode` and `python-ts-mode` inherit. In my personal configuration I therefore just use `python-base-mode-hook`  and `python-base-mode-map`, but this would not be backward compatible to older emacs versions, therefore I suggest just adding to both the normal and ts-modes the keybindings and hooks.

This is something should also be addressed for other programming major modes in the feature and I'm not sure if this has been discussed anywhere. One could also think of defining support for those modes in separate files, but not sure if that's necessary since the ts-mode and original-modes are also defined in the same files, and the setup will be probably identical for both.

I'm definetly not an expert when  it comes to tree-sitter and sadly this PR doesn't have a general solution for all modes, so I'm free if this will be rejected. But this is the fork I use now and at least I'd like to get a discussion started about the ts-modes.

### Checklist

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-python-setup` with `defun`
- [x] define `evil-collection-python-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-python-`
