### PR TITLE
Add "ext:" to declare-function invocations

### DIFF
--- a/modes/beginend/evil-collection-beginend.el
+++ b/modes/beginend/evil-collection-beginend.el
@@ -70,7 +70,7 @@ newly defined motion."
         (beginend-beginning-fn-name (intern (format "beginend-%s-goto-beginning" ec-mode-name)))
         (beginend-map-name (intern (format "beginend-%s-map" ec-mode-name))))
     `(progn
-       (declare-function ,beginend-beginning-fn-name "beginend")
+       (declare-function ,beginend-beginning-fn-name "ext:beginend")
        (evil-define-motion ,motion-name (count)
          :jump t
          :type line
@@ -92,7 +92,7 @@ newly defined motion."
         (beginend-end-fn-name (intern (format "beginend-%s-goto-end" ec-mode-name)))
         (beginend-map-name (intern (format "beginend-%s-map" ec-mode-name))))
     `(progn
-       (declare-function ,beginend-end-fn-name "beginend")
+       (declare-function ,beginend-end-fn-name "ext:beginend")
        (evil-define-motion ,motion-name (count)
          :jump t
          :type line


### PR DESCRIPTION
This is technically required for Lisp files that are not part of core Emacs.