### PR TITLE
vterm: fix the `x' key, currently it does nothing

### DIFF
--- a/modes/vterm/evil-collection-vterm.el
+++ b/modes/vterm/evil-collection-vterm.el
@@ -150,7 +150,7 @@ Save in REGISTER or in the kill-ring with YANK-HANDLER."
 
 (evil-define-operator evil-collection-vterm-delete-char (beg end type register)
   "Delete current character."
-  :motion evil-delete-char
+  :motion evil-forward-char
   (interactive "<R><x>")
   (evil-collection-vterm-delete beg end type register))
 


### PR DESCRIPTION
Currently, pressing the `x` key in normal mode does nothing. I don't know much about `:motion` but AFAIK `evil-delete-char` doesn't exist. Using `evil-forward-char` fixes the issue.