### PR TITLE
cider debugger keybindings

### DIFF
--- a/modes/cider/evil-collection-cider.el
+++ b/modes/cider/evil-collection-cider.el
@@ -77,7 +77,9 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
                                           "eval"
                                           "inject"
                                           "inspect"
-                                          "locals")
+                                          "locals"
+                                          "in"
+                                          "stacktrace")
 
 ;;;###autoload
 (defun evil-collection-cider-setup ()
@@ -104,7 +106,9 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
       "q" 'evil-collection-cider-debug-quit
       "e" 'evil-collection-cider-debug-eval
       "J" 'evil-collection-cider-debug-inject
-      "I" 'evil-collection-cider-debug-inspect
+      "I" 'evil-collection-cider-debug-in
+      "p" 'evil-collection-cider-debug-inspect
+      "s" 'evil-collection-cider-debug-stacktrace
       "L" 'evil-collection-cider-debug-locals
       "H" 'cider-debug-move-here))
 


### PR DESCRIPTION
I added keybindings for the "step in" and "show stacktrace" commands,
in normal cider documentation, and the underlined letter in the debugging menu where it shows what key for each command, step-in is i and inspect is p, so I changed inspect's binding from i to p, and gave i to "step in"