### PR TITLE
Use evil-lookup-key when translating keys

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -744,7 +744,7 @@ without creating/referencing a backup keymap."
                         unless (keywordp key)
                         collect key
                         and collect (when replacement
-                                      (lookup-key lookup-keymap replacement)))))
+                                      (evil-lookup-key lookup-keymap replacement)))))
     (unless (or destructive
                 (boundp backup-keymap-symbol))
       (set backup-keymap-symbol lookup-keymap))
@@ -775,7 +775,7 @@ without creating/referencing a backup keymap."
                         unless (keywordp key)
                         collect key
                         and collect (when replacement
-                                      (lookup-key lookup-keymap replacement)))))
+                                      (evil-lookup-key lookup-keymap replacement)))))
     (unless (or destructive
                 (boundp backup-keymap-symbol))
       (set backup-keymap-symbol lookup-keymap))


### PR DESCRIPTION
Makes it possible to indiscriminately translate multi-key sequences like "gj" without errors. Using plain `lookup-key` will end up binding a bunch of keys to a number like 1 instead of a command, because it returns a number when it's passed an invalid sequence of prefix characters. `evil-lookup-key` discards those numbers and returns nil instead.

For example, based on the documentation, here's what someone (i.e. me) might try if they wanted to use `evil-mode` and `evil-collection` with another keyboard layout.

```emacs-lisp
(defvar evil-colemak-dh-translations
  '("n" "j"  "N" "J"
    "e" "k"  "E" "K"
    "m" "h"  "M" "H"
    "i" "l"  "I" "L"
    "k" "n"  "K" "N"
    "h" "m"  "H" "M"
    "u" "i"  "U" "I"
    "l" "u"  "L" "U"
    "j" "e"  "J" "E"

    "gn" "gj"  "gN" "gJ"
    "ge" "gk"  "gE" "gK"
    "gm" "gh"  "gM" "gH"
    "gi" "gl"  "gI" "gL"
    "gk" "gn"  "gK" "gN"
    "gh" "gm"  "gH" "gM"
    "gu" "gi"  "gU" "gI"
    "gl" "gu"  "gL" "gU"
    "gj" "ge"  "gJ" "gE")
  "Evil keys to translate for the Colemak-DH keyboard layout.")

;; Translate the main evil-mode bindings.
(apply #'evil-collection-translate-key
       nil
       '(evil-normal-state-map
         evil-motion-state-map
         evil-operator-state-map
         evil-visual-state-map
         evil-window-map)
       evil-colemak-dh-translations)

;; Install a hook to translate bindings from evil-collection.

(defun evil-colemak-dh-translate-keys (mode keymaps &optional states &rest _rest)
  "Translate bindings for MODE in KEYMAPS for the Colemak-DH layout in STATES."
  (apply #'evil-collection-translate-key
         (or states '(normal motion visual))
         keymaps
         evil-colemak-dh-translations))
(add-hook 'evil-collection-setup-hook #'evil-colemak-dh-translate-keys)
```

This works pretty well for all of the single character bindings, leaving only a handful of bindings that need to be tweaked manually. But many of the bindings that start with "g" above are broken without this patch, getting bound to the number 1 and giving an error when they are invoked.

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [ ] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
