### PR TITLE
vertico: fix scroll direction of C-u/C-d

### DIFF
--- a/modes/vertico/evil-collection-vertico.el
+++ b/modes/vertico/evil-collection-vertico.el
@@ -38,13 +38,13 @@
   (when evil-collection-setup-minibuffer
     (when evil-want-C-u-scroll
       (evil-collection-define-key 'normal 'vertico-map
-        (kbd "C-u") 'vertico-scroll-up)
+        (kbd "C-u") 'vertico-scroll-down)
       (unless evil-want-C-u-delete
         (evil-collection-define-key 'insert 'vertico-map
-          (kbd "C-u") 'vertico-scroll-up)))
+          (kbd "C-u") 'vertico-scroll-down)))
     (when evil-want-C-d-scroll
       (evil-collection-define-key 'normal 'vertico-map
-        (kbd "C-d") 'vertico-scroll-down))
+        (kbd "C-d") 'vertico-scroll-up))
 
     (evil-collection-define-key 'normal 'vertico-map
       "gj" 'vertico-next-group


### PR DESCRIPTION
### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/your/awesome_package

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [ ] byte-compiles cleanly
- [ ] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
