### PR TITLE
mu4e: fix mu4e--main-toggle-main-sending-mode function name

### DIFF
--- a/modes/mu4e/evil-collection-mu4e-1.8.el
+++ b/modes/mu4e/evil-collection-mu4e-1.8.el
@@ -142,7 +142,7 @@ with older release versions of `mu4e.'"
      "x" mu4e-kill-update-mail
      "A" mu4e-about
      "f" smtpmail-send-queued-mail
-     "m" mu4e~main-toggle-mail-sending-mode
+     "m" mu4e--main-toggle-mail-sending-mode
      "s" mu4e-search
      "q" mu4e-quit)
 

--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -127,7 +127,7 @@
        "x" mu4e-kill-update-mail
        "A" mu4e-about
        "f" smtpmail-send-queued-mail
-       "m" mu4e~main-toggle-mail-sending-mode
+       "m" mu4e--main-toggle-mail-sending-mode
        "s" mu4e-search
        "q" mu4e-quit)
 


### PR DESCRIPTION
Commit https://github.com/djcb/mu/commit/a4707afe1218330eb5bd0a6cc0b2984844643d7e (even before mu 1.8.0) changed the name of `mu4e~main-toggle-mail-sending-mode` function to `mu4e--main-toggle-mail-sending-mode`. That caused my configuration to throw:

```
error in process filter: mu4e-error: [mu4e] No binding for mu4e--main-toggle-mail-sending-mode
```

I've renamed that function and everything works now.