### PR TITLE
helm: hide evil cursor in minibuffer

### DIFF
--- a/modes/helm/evil-collection-helm.el
+++ b/modes/helm/evil-collection-helm.el
@@ -74,7 +74,10 @@
         (overlay-put ov 'window (selected-window))
         (overlay-put ov 'face (let ((bg-color (face-background 'default nil)))
                                 `(:background ,bg-color :foreground ,bg-color)))
-        (setq-local cursor-type nil)))))
+        (setq-local cursor-type nil
+                    evil-emacs-state-cursor '(nil +evil-emacs-cursor-fn)
+                    evil-normal-state-cursor '(nil +evil-default-cursor-fn)
+                    evil-insert-state-cursor '(nil +evil-default-cursor-fn))))))
 
 (defun evil-collection-helm--set-prompt-display (pos)
   (let (beg state region-active m)

--- a/modes/helm/evil-collection-helm.el
+++ b/modes/helm/evil-collection-helm.el
@@ -75,9 +75,9 @@
         (overlay-put ov 'face (let ((bg-color (face-background 'default nil)))
                                 `(:background ,bg-color :foreground ,bg-color)))
         (setq-local cursor-type nil
-                    evil-emacs-state-cursor '(nil +evil-emacs-cursor-fn)
-                    evil-normal-state-cursor '(nil +evil-default-cursor-fn)
-                    evil-insert-state-cursor '(nil +evil-default-cursor-fn))))))
+                    evil-emacs-state-cursor nil
+                    evil-normal-state-cursor nil
+                    evil-insert-state-cursor nil)))))
 
 (defun evil-collection-helm--set-prompt-display (pos)
   (let (beg state region-active m)


### PR DESCRIPTION
### Brief summary of what the package does

Hi, 

This PR enables hiding cursor in minibuffer when a Helm session is active.

I fixed the issue that was previously mentioned in https://github.com/emacs-evil/evil-collection/issues/63, but it wasn't fixed until now.

Can you consider merging?

Thanks!

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
