### PR TITLE
evil-collection-docker.el: add 'docker-context-*' bindings

### DIFF
--- a/modes/docker/evil-collection-docker.el
+++ b/modes/docker/evil-collection-docker.el
@@ -26,6 +26,7 @@
 (require 'evil-collection)
 
 (defconst evil-collection-docker-maps '(docker-container-mode-map
+					docker-context-mode-map
                                         docker-image-mode-map
                                         docker-machine-mode-map
                                         docker-network-mode-map

--- a/modes/docker/evil-collection-docker.el
+++ b/modes/docker/evil-collection-docker.el
@@ -51,6 +51,12 @@
     "f"  'docker-container-open
     "r"  'docker-container-rename-selection)
 
+  (evil-collection-define-key 'normal 'docker-context-mode-map
+    "?"  'docker-context-help
+    "D"  'docker-context-rm
+    "I"  'docker-context-inspect
+    "X"  'docker-context-use)
+
   (evil-collection-define-key 'normal 'docker-image-mode-map
     ";"  'docker-image-ls
     "?"  'docker-image-help


### PR DESCRIPTION
### Brief summary of what the package does

This add support for `docker-context-*` commands in `evil-collection-docker.el`.

### Direct link to the package repository

Commands added in https://github.com/Silex/docker.el/commit/bd8f189b445a3ae7f539fac00e98627f76aaa8e2

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
