### PR TITLE
Fix typo in ement.el

### DIFF
--- a/modes/ement/evil-collection-ement.el
+++ b/modes/ement/evil-collection-ement.el
@@ -70,7 +70,7 @@
   (evil-collection-define-key '(normal motion) 'ement-room-mode-map
     (kbd "<")  'ement-room-transient
     (kbd "<return>")   'ement-room-send-message
-    (kbd "RET")        'ement-rooom-send-message
+    (kbd "RET")        'ement-room-send-message
     (kbd "M-RET")      'ement-room-compose-message
     (kbd "<M-return>") 'ement-room-compose-message
     (kbd "a")  'ement-room-send-message


### PR DESCRIPTION
I noticed this typo in the new ement.el module just after it got merged.  I apologize for not actually looking at the code at the time I commented on the PR!