### PR TITLE
evil-collection-elpaca-setup: update command name

### DIFF
--- a/modes/elpaca/evil-collection-elpaca.el
+++ b/modes/elpaca/evil-collection-elpaca.el
@@ -93,7 +93,7 @@ If this is nil, match original `elpaca' behavior."
     (kbd "gr") 'elpaca-ui-search-refresh
     (kbd "c") 'elpaca-ui-copy
     (kbd "d") 'elpaca-ui-mark-delete
-    (kbd "i") 'elpaca-ui-mark-install
+    (kbd "i") 'elpaca-ui-mark-try
     (kbd "m") 'elpaca-manager
     (kbd "r") 'elpaca-ui-mark-rebuild
     (kbd "s") 'elpaca-ui-search


### PR DESCRIPTION
elpaca-ui-mark-install has been replaced upstream by elpaca-ui-mark-try.



### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
