### PR TITLE
Set local-buffer value for evil-shift-width

### DIFF
--- a/modes/lua-mode/evil-collection-lua-mode.el
+++ b/modes/lua-mode/evil-collection-lua-mode.el
@@ -35,7 +35,7 @@
 
 (defun evil-collection-lua-mode-set-evil-shift-width ()
   "Set `evil-shift-width' according to `lua-indent-level'."
-  (setq evil-shift-width lua-indent-level))
+  (setq-local evil-shift-width lua-indent-level))
 
 ;;;###autoload
 (defun evil-collection-lua-mode-setup ()

--- a/modes/python/evil-collection-python.el
+++ b/modes/python/evil-collection-python.el
@@ -36,7 +36,7 @@
 
 (defun evil-collection-python-set-evil-shift-width ()
   "Set `evil-shift-width' according to `python-indent-offset'."
-  (setq evil-shift-width python-indent-offset))
+  (setq-local evil-shift-width python-indent-offset))
 
 ;;;###autoload
 (defun evil-collection-python-setup ()

--- a/modes/ruby-mode/evil-collection-ruby-mode.el
+++ b/modes/ruby-mode/evil-collection-ruby-mode.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-ruby-mode-set-evil-shift-width ()
   "Set `evil-shift-width' according to `ruby-indent-level'."
-  (setq evil-shift-width ruby-indent-level))
+  (setq-local evil-shift-width ruby-indent-level))
 
 ;;;###autoload
 (defun evil-collection-ruby-mode-setup ()

--- a/modes/sh-script/evil-collection-sh-script.el
+++ b/modes/sh-script/evil-collection-sh-script.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-sh-script-set-evil-shift-width ()
   "Set `evil-shift-width' according to `sh-basic-offset'."
-  (setq evil-shift-width sh-basic-offset))
+  (setq-local evil-shift-width sh-basic-offset))
 
 ;;;###autoload
 (defun evil-collection-sh-script-setup ()

--- a/modes/typescript-mode/evil-collection-typescript-mode.el
+++ b/modes/typescript-mode/evil-collection-typescript-mode.el
@@ -34,7 +34,7 @@
 
 (defun evil-collection-typescript-mode-set-evil-shift-width ()
   "Set `evil-shift-width' according to `typescript-indent-level'."
-  (setq evil-shift-width typescript-indent-level))
+  (setq-local evil-shift-width typescript-indent-level))
 
 ;;;###autoload
 (defun evil-collection-typescript-mode-setup ()

--- a/modes/yaml-mode/evil-collection-yaml-mode.el
+++ b/modes/yaml-mode/evil-collection-yaml-mode.el
@@ -31,7 +31,7 @@
 (defvar yaml-indent-offset)
 (defun evil-collection-yaml-mode-set-evil-shift-width ()
   "Set `evil-shift-width' according to `yaml-indent-offset'."
-  (setq evil-shift-width yaml-indent-offset))
+  (setq-local evil-shift-width yaml-indent-offset))
 
 ;;;###autoload
 (defun evil-collection-yaml-mode-setup ()


### PR DESCRIPTION
Since commit https://github.com/emacs-evil/evil/commit/b27997b693dca40a08bfea00ae961f10bf839c0c, `evil-shift-width` is no longer buffer-local by default.

So with current versions of `evil` and `evil-collection`, this leads to inconsistent `evil-shift-width` value in some cases. For example:
- open a YAML file (`evil-shift-width` is globally set to `yaml-indent-offset` ; 2 by default)
- then open a Python file (`evil-shift-width` is now globally set to `python-indent-offset` ; 4 by default)
- switch back to the YAML buffer: the global value of `evil-shift-width` is used (here 4) so the shifting operators (> and <) don't work as expected

This PR fix the problem for all modes that set `evil-shift-value`.