### PR TITLE
all continue-all in cider-debug mode

### DIFF
--- a/modes/cider/evil-collection-cider.el
+++ b/modes/cider/evil-collection-cider.el
@@ -72,6 +72,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
 
 (evil-collection-cider-make-debug-command "next"
                                           "continue"
+                                          "continue-all"
                                           "out"
                                           "quit"
                                           "eval"
@@ -102,6 +103,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
       "b" 'cider-debug-defun-at-point
       "n" 'evil-collection-cider-debug-next
       "c" 'evil-collection-cider-debug-continue
+      "C" 'evil-collection-cider-debug-continue-all
       "o" 'evil-collection-cider-debug-out
       "q" 'evil-collection-cider-debug-quit
       "e" 'evil-collection-cider-debug-eval


### PR DESCRIPTION
I just added one keybinding "C" for "Continue without stopping for all breakpoints", consistent with the standard emacs keybindings documented by [cider](https://docs.cider.mx/cider/debugging/debugger.html), and with evil-collections existing cider-debug keybindings (lowercase "c" is already continue until the next breakpoint). Just adding capital "C" so it matches cider: "c" for continue till next breakpoint, "C" for continue without any more breakpoints, leaving the debugger