### PR TITLE
diff-hl: fix name incompatible

### DIFF
--- a/modes/diff-hl/evil-collection-diff-hl.el
+++ b/modes/diff-hl/evil-collection-diff-hl.el
@@ -68,7 +68,8 @@
     "p" 'diff-hl-show-hunk-previous
     "n" 'diff-hl-show-hunk-next
     "c" 'diff-hl-show-hunk-copy-original-text
-    "r" 'diff-hl-show-hunk-revert-hunk))
+    "r" 'diff-hl-show-hunk-revert-hunk
+    "S" 'diff-hl-show-hunk-stage-hunk))
 
 (provide 'evil-collection-diff-hl)
 ;;; evil-collection-diff-hl.el ends here

--- a/modes/diff-hl/evil-collection-diff-hl.el
+++ b/modes/diff-hl/evil-collection-diff-hl.el
@@ -42,7 +42,7 @@
 ;;; Code:
 (require 'evil-collection)
 
-(defconst evil-collection-diff-hl-maps '(diff-hl-show-hunk--inline-popup-map
+(defconst evil-collection-diff-hl-maps '(diff-hl-show-hunk-map
                                          diff-hl-inline-popup-transient-mode-map))
 
 ;;;###autoload
@@ -63,7 +63,7 @@
 
   ;; Actually `diff-hl-inline-popup-transient-mode-map' will inherit it by
   ;; `set-keymap-parent'.
-  (evil-collection-define-key 'normal 'diff-hl-show-hunk--inline-popup-map
+  (evil-collection-define-key 'normal 'diff-hl-show-hunk-map
     ;; Keep it the same as the overlay shows.
     "p" 'diff-hl-show-hunk-previous
     "n" 'diff-hl-show-hunk-next


### PR DESCRIPTION
Issue: evil keybinding doesn't work with diff-hl popup