### PR TITLE
mu4e: add mu4e-headers-toggle-property

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -178,6 +178,7 @@
        "gj" mu4e-headers-next-unread
        "\C-j" mu4e-headers-next
        "\C-k" mu4e-headers-prev
+       "t" mu4e-headers-toggle-property
        "zr" mu4e-headers-toggle-include-related
        "zt" mu4e-headers-toggle-threading
        "zd" mu4e-headers-toggle-skip-duplicates


### PR DESCRIPTION
mu4e-headers-toggle-property replaced the following three toggle
commands (which are now aliases for the new command) in v1.9.5. It
provides its own menu with a key binding for each property, so bind it
to a one-key binding.

The obsolete command bindings are not removed because mu4e is typically
installed with mu via the system package manager and is therefore harder
to upgrade than a typical Emacs package. mu4e-headers-toggle-property
was also renamed to mu4e-search-toggle-property in 1.9.11, but the old
name (which remains as an alias) is preferred for the same reason.

-------

### Checklist

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy.

<!-- After submitting, please fix any problems the CI reports. -->