### PR TITLE
feat(cider): add force-out, inspect-prompt, trace 

### DIFF
--- a/modes/cider/evil-collection-cider.el
+++ b/modes/cider/evil-collection-cider.el
@@ -70,20 +70,20 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
                (interactive)
                (cider-debug-mode-send-reply ,(format ":%s" command))))))))
 
-(evil-collection-cider-make-debug-command "next"
-                                          "continue"
+(evil-collection-cider-make-debug-command "continue"
                                           "continue-all"
+                                          "next"
+                                          "in"
                                           "out"
                                           "force-out"
-                                          "quit"
                                           "eval"
-                                          "inject"
                                           "inspect"
                                           "inspect-prompt"
                                           "locals"
-                                          "in"
+                                          "inject"
                                           "stacktrace"
-                                          "trace")
+                                          "trace"
+                                          "quit")
 
 ;;;###autoload
 (defun evil-collection-cider-setup ()
@@ -104,21 +104,21 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
 
     (evil-collection-define-key 'normal 'cider--debug-mode-map
       "b" 'cider-debug-defun-at-point
-      "n" 'evil-collection-cider-debug-next
       "c" 'evil-collection-cider-debug-continue
       "C" 'evil-collection-cider-debug-continue-all
+      "n" 'evil-collection-cider-debug-next
+      "I" 'evil-collection-cider-debug-in
       "o" 'evil-collection-cider-debug-out
       "O" 'evil-collection-cider-debug-force-out
-      "q" 'evil-collection-cider-debug-quit
+      "H" 'cider-debug-move-here
       "e" 'evil-collection-cider-debug-eval
-      "J" 'evil-collection-cider-debug-inject
-      "I" 'evil-collection-cider-debug-in
       "p" 'evil-collection-cider-debug-inspect
       "P" 'evil-collection-cider-debug-inspect-prompt
+      "L" 'evil-collection-cider-debug-locals
+      "J" 'evil-collection-cider-debug-inject
       "s" 'evil-collection-cider-debug-stacktrace
       "t" 'evil-collection-cider-debug-trace
-      "L" 'evil-collection-cider-debug-locals
-      "H" 'cider-debug-move-here))
+      "q" 'evil-collection-cider-debug-quit))
 
   (evil-collection-define-key '(normal visual) 'cider-mode-map
     "gd" 'cider-find-var

--- a/modes/cider/evil-collection-cider.el
+++ b/modes/cider/evil-collection-cider.el
@@ -74,13 +74,16 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
                                           "continue"
                                           "continue-all"
                                           "out"
+                                          "force-out"
                                           "quit"
                                           "eval"
                                           "inject"
                                           "inspect"
+                                          "inspect-prompt"
                                           "locals"
                                           "in"
-                                          "stacktrace")
+                                          "stacktrace"
+                                          "trace")
 
 ;;;###autoload
 (defun evil-collection-cider-setup ()
@@ -105,12 +108,15 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
       "c" 'evil-collection-cider-debug-continue
       "C" 'evil-collection-cider-debug-continue-all
       "o" 'evil-collection-cider-debug-out
+      "O" 'evil-collection-cider-debug-force-out
       "q" 'evil-collection-cider-debug-quit
       "e" 'evil-collection-cider-debug-eval
       "J" 'evil-collection-cider-debug-inject
       "I" 'evil-collection-cider-debug-in
       "p" 'evil-collection-cider-debug-inspect
+      "P" 'evil-collection-cider-debug-inspect-prompt
       "s" 'evil-collection-cider-debug-stacktrace
+      "t" 'evil-collection-cider-debug-trace
       "L" 'evil-collection-cider-debug-locals
       "H" 'cider-debug-move-here))
 


### PR DESCRIPTION
This is not a new package, just additions to `cider--debug-mode-map`'s map

#### feat(cider): add force-out, inspect-prompt, trace <sup>c70a83c</sup>
Matches cider's existing keybindings on `cider--debug-mode-map`

#### refactor(cider): match cider-debug.el command order <sup>89a317a</sup>
Since it's already not intentionally ordered (e.g alphabetical),
matching upstream's order helps when eyeballing additions.

Thank you for evil collection 🥳!