### PR TITLE
fix bufler RET keybind

### DIFF
--- a/modes/bufler/evil-collection-bufler.el
+++ b/modes/bufler/evil-collection-bufler.el
@@ -50,7 +50,7 @@
     "r"   'bufler-list-buffer-name-workspace
     "D"   'bufler-list-buffer-kill
     "w"   'bufler-list-buffer-save
-    "RET" 'bufler-list-buffer-switch
+    (kbd "RET") 'bufler-list-buffer-switch
     "J"   'bufler-list-buffer-peek))
 
 (provide 'evil-collection-bufler)


### PR DESCRIPTION
### Brief summary of what the package does

fix #764 

### Direct link to the package repository

https://github.com/your/awesome_package

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [ ] byte-compiles cleanly
- [ ] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
