### PR TITLE
Fix the new `corfu--setup` signature (backward compatible)

### DIFF
--- a/modes/corfu/evil-collection-corfu.el
+++ b/modes/corfu/evil-collection-corfu.el
@@ -126,7 +126,7 @@ This key theme variable may be refactored in the future so use with caution."
     (evil-collection-define-key 'insert 'corfu-map
       (kbd "C-d") 'corfu-scroll-down))
 
-  (advice-add 'corfu--setup :after 'evil-normalize-keymaps)
+  (advice-add 'corfu--setup :after (lambda (&rest _) (evil-normalize-keymaps)))
   (advice-add 'corfu--teardown :after 'evil-normalize-keymaps))
 
 (provide 'evil-collection-corfu)


### PR DESCRIPTION
This PR fixes this issue reported in `corfu`'s repository:

https://github.com/minad/corfu/issues/403

It is caused by a change of signature of the `corfu--setup` function, causing the advice defined by `evil-collection-corfu` to call the advised function with the wrong number of arguments.

This PR fixes this while staying backward compatible with the previous `corfu--setup` signature.