### PR TITLE
Pdf: Fix typo

### DIFF
--- a/modes/pdf/evil-collection-pdf.el
+++ b/modes/pdf/evil-collection-pdf.el
@@ -177,7 +177,7 @@ Consider COUNT."
   (when evil-want-C-d-scroll
     (evil-collection-define-key 'normal 'pdf-view-mode-map
       (kbd "C-d") 'pdf-view-scroll-up-or-next-page))
-  (when evil-want-C-d-scroll
+  (when evil-want-C-u-scroll
     (evil-collection-define-key 'normal 'pdf-view-mode-map
       (kbd "C-u") 'pdf-view-scroll-down-or-previous-page))
 


### PR DESCRIPTION
Unless intended, `evil-want-C-d-scroll` should not imply a `C-u` scroll binding