### PR TITLE
vterm: Visual consistency for append

### DIFF
--- a/modes/vterm/evil-collection-vterm.el
+++ b/modes/vterm/evil-collection-vterm.el
@@ -100,14 +100,14 @@ after the prompt."
 (defun evil-collection-vterm-append ()
   "Append character after cursor."
   (interactive)
-  (vterm-goto-char (point))
-  (call-interactively #'evil-append))
+  (vterm-goto-char (1+ (point)))
+  (call-interactively #'evil-insert))
 
 (defun evil-collection-vterm-append-line ()
   "Append character at end-of-line."
   (interactive)
   (vterm-goto-char (vterm--get-end-of-line))
-  (call-interactively #'evil-append))
+  (call-interactively #'evil-insert))
 
 (declare-function vterm-yank "vterm")
 


### PR DESCRIPTION
`evil-collection-vterm-append` doesn't work, and `evil-collection-vterm-append-line` doesn't correctly display where the cursor is located. This fixes both issues.

The **problem** with both commands lies in the fact that `evil-append` **doesn't accurately place the insert-mode cursor in front of the cursor displayed in normal-mode**; instead acting in a functionally identical way as `evil-insert`, but moving only the displayed cursor forward one character until a character is placed.

Moving the cursor forward one character before entering insert mode solves `evil-collection-vterm-append`'s issues. I haven't encountered any unexpected behaviour  with the edge-case scenario of moving the cursor forward at the end of a line, which is the only situation I thought might be problematic with this solution.

The only fault with `evil-collection-vterm-append-line` is where the cursor is displayed, not where it actually is at the time of editing, contrary to what happened with `evil-collection-vterm-append`. Therefore, all that is necessary is to move backwards one character the displayed cursor when entering insert-mode, which can be easily achieved by swapping `evil-append` for `evil-insert`.

### Direct link to the package repository

https://github.com/miguebox/evil-collection/tree/pull-request