### PR TITLE
CIDER: Only use cider-find-var when cider-use-xref is nil

### DIFF
--- a/modes/cider/evil-collection-cider.el
+++ b/modes/cider/evil-collection-cider.el
@@ -121,22 +121,28 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
       "q" 'evil-collection-cider-debug-quit))
 
   (evil-collection-define-key '(normal visual) 'cider-mode-map
-    "gd" 'cider-find-var
-    (kbd "C-t") 'cider-pop-back
     "gz" 'cider-switch-to-repl-buffer
     "gf" 'cider-find-resource
     "K" 'cider-doc)
+
+  (unless cider-use-xref
+    (evil-collection-define-key '(normal visual) 'cider-mode-map
+      "gd" 'cider-find-var
+      (kbd "C-t") 'cider-pop-back))
 
   (evil-collection-define-key '(normal visual) 'cider-repl-mode-map
     ;; FIXME: This seems to get overwritten by `cider-switch-to-repl-buffer'.
     "gz" 'cider-switch-to-last-clojure-buffer
     (kbd "RET") 'cider-repl-return
 
-    "gd" 'cider-find-var
-    (kbd "C-t") 'cider-pop-back
     "gr" 'cider-refresh
     "gf" 'cider-find-resource
     "K" 'cider-doc)
+
+  (unless cider-use-xref
+    (evil-collection-define-key '(normal visual) 'cider-repl-mode-map
+      "gd" 'cider-find-var
+      (kbd "C-t") 'cider-pop-back))
 
   (evil-collection-define-key '(normal visual) 'cider-repl-history-mode-map
     (kbd "C-k") 'cider-repl-history-previous
@@ -180,7 +186,7 @@ ex. \(cider-debug-mode-send-reply \":next\"\)"
     "r" 'cider-macroexpand-again
     "K" 'cider-doc ; Evil has `evil-lookup'.
     "J" 'cider-javadoc
-    "." 'cider-find-var
+    "." (if cider-use-xref 'xref-find-definitions 'cider-find-var)
     "m" 'cider-macroexpand-1-inplace
     "a" 'cider-macroexpand-all-inplace
     "u" 'cider-macroexpand-undo


### PR DESCRIPTION
Closes: #776

Follows the behavior of `cider-use-xref` in CIDER. When `cider-use-xref` is non nil (the default), it doesn't bind `cider-find-var` nor `cider-pop-back`.

Documentation of this feature in the CIDER docs: https://docs.cider.mx/cider/usage/misc_features.html#xref-integration