### PR TITLE
corfu: bind up/down in insert state

### DIFF
--- a/modes/corfu/evil-collection-corfu.el
+++ b/modes/corfu/evil-collection-corfu.el
@@ -82,6 +82,8 @@ This key theme variable may be refactored in the future so use with caution."
       (kbd "C-k") 'corfu-previous
       (kbd "M-j") 'corfu-next
       (kbd "M-k") 'corfu-previous
+      (kbd "<down>") 'corfu-next
+      (kbd "<up>") 'corfu-previous
       (kbd "<escape>") 'evil-collection-corfu-quit-and-escape))
 
   ;; https://github.com/minad/corfu#tab-and-go-completion


### PR DESCRIPTION
Corfu already binds up/down in emacs state, but not in insert state. Normally this is not a problem, but when using corfu in comint-mode like with chatgpt-shell, up/down moves in the history instead of moving in the corfu completions.