### PR TITLE
pdf: implement evil yank to registers

### DIFF
--- a/modes/pdf/evil-collection-pdf.el
+++ b/modes/pdf/evil-collection-pdf.el
@@ -42,6 +42,9 @@
 (declare-function pdf-view-goto-page "pdf-view")
 (declare-function pdf-view-previous-line-or-previous-page "pdf-view")
 (declare-function pdf-view-next-line-or-next-page "pdf-view")
+(declare-function pdf-view-assert-active-region "pdf-view")
+(declare-function pdf-view-active-region-text "pdf-view")
+(declare-function pdf-view-deactivate-region "pdf-view")
 (declare-function pdf-history-forward "pdf-history")
 (declare-function pdf-history-backward "pdf-history")
 
@@ -83,6 +86,17 @@ Consider COUNT."
 Consider COUNT."
   (interactive "P")
   (pdf-history-backward (or count 1)))
+
+(defun evil-collection-pdf-yank ()
+  "Save the text of the active region into the currently selected register."
+  (interactive)
+  (pdf-view-assert-active-region)
+  (let ((txt (pdf-view-active-region-text))
+        (reg evil-this-register))
+    (pdf-view-deactivate-region)
+    (evil-set-register
+     (or reg ?\")
+     (mapconcat #'identity txt nil))))
 
 ;;;###autoload
 (defun evil-collection-pdf-setup ()
@@ -182,7 +196,7 @@ Consider COUNT."
       (kbd "C-u") 'pdf-view-scroll-down-or-previous-page))
 
   (evil-collection-define-key 'visual 'pdf-view-mode-map
-    "y" 'pdf-view-kill-ring-save)
+    "y" 'evil-collection-pdf-yank)
 
   (evil-collection-inhibit-insert-state 'pdf-history-minor-mode-map)
   (evil-set-initial-state 'pdf-history-minor-mode 'normal)


### PR DESCRIPTION
Evil users expect to be able to yank to named registers, but pdf-view only gives us `pdf-view-kill-ring-save'. So we implement our own version of evil-yank for pdf-view buffers.