### PR TITLE
corfu: allow corfu to be used when evil is disabled

### DIFF
--- a/modes/corfu/evil-collection-corfu.el
+++ b/modes/corfu/evil-collection-corfu.el
@@ -89,7 +89,7 @@ This key theme variable may be refactored in the future so use with caution."
      (const
       :tag "Magic Backspace" magic-backspace))))
 
-(defcustom evil-collection-corfu-supported-states '(insert replace emacs)
+(defcustom evil-collection-corfu-supported-states '(insert replace emacs nil)
   "The `evil-state's which `corfu' function can be requested."
   :type '(repeat symbol))
 


### PR DESCRIPTION
This fixes #801. Basically, we do not usually enable `evil-mode` in the minibuffer so we should allow Corfu to work when the current `evil-state` is `nil`.