### PR TITLE
corfu: don't suppress popup when evil is disabled

### DIFF
--- a/modes/corfu/evil-collection-corfu.el
+++ b/modes/corfu/evil-collection-corfu.el
@@ -89,7 +89,7 @@ This key theme variable may be refactored in the future so use with caution."
      (const
       :tag "Magic Backspace" magic-backspace))))
 
-(defcustom evil-collection-corfu-supported-states '(insert replace emacs)
+(defcustom evil-collection-corfu-supported-states '(nil insert replace emacs)
   "The `evil-state's which `corfu' function can be requested."
   :type '(repeat symbol))
 


### PR DESCRIPTION
PR #800 made it impossible to use Corfu whenever Evil wasn't initialized (eg. in the minibuffer when `evil-want-minibuffer` is nil). This fixes that.

Amend: #800