### PR TITLE
ci: Use Eask to test macos and windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,34 +7,47 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        emacs_version:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
           - 26.3
           - 27.2
           - 28.2
-          - 29.2
-          - snapshot
+          - 29.3
+        experimental: [false]
+        include:
+          - os: ubuntu-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: macos-latest
+            emacs-version: snapshot
+            experimental: true
     steps:
-    - uses: purcell/setup-emacs@master
+    - uses: jcs090218/setup-emacs@master
       with:
-        version: ${{ matrix.emacs_version }}
+        version: ${{ matrix.emacs-version }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Print emacs version
       run: |
         emacs --version
 
-    - uses: cask/setup-cask@master
+    - uses: emacs-eask/setup-eask@master
       with:
         version: snapshot
 
-    - run: cask install
+    - run: make install
 
     - run: make compile
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.cask
+/.eask
+/dist
 *.elc

--- a/Eask
+++ b/Eask
@@ -6,7 +6,7 @@
 (keywords "evil" "tools")
 
 (package-file "evil-collection.el")
-(files "modes/*/*.el")
+(files "modes/*/*.el" '(:exclude "modes/magit/*.el"))
 
 (script "test" "echo \"Error: no test specified\" && exit 1")
 

--- a/Eask
+++ b/Eask
@@ -34,6 +34,7 @@
 
 (add-hook 'eask-before-lint/package-hook
            (lambda (&rest _)
+             (advice-add 'package-lint--error-at-bol :around 'ignore)  ; ignore headers
              (advice-add 'package-lint--check-eval-after-load :around 'ignore)
              (advice-add 'package-lint--check-version-regexp-list :around 'ignore)
              (advice-add 'package-lint--check-symbol-separators :around 'ignore)

--- a/Eask
+++ b/Eask
@@ -6,6 +6,7 @@
 (keywords "evil" "tools")
 
 (package-file "evil-collection.el")
+(files "modes/*/*.el")
 
 (script "test" "echo \"Error: no test specified\" && exit 1")
 

--- a/Eask
+++ b/Eask
@@ -1,0 +1,40 @@
+(package "evil-collection"
+         "0.0.2"
+         "A set of keybindings for Evil mode")
+
+(website-url "https://github.com/emacs-evil/evil-collection")
+(keywords "evil" "tools")
+
+(package-file "evil-collection.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source 'gnu)
+(source 'melpa)
+
+(depends-on "emacs" "26.3")
+(depends-on "evil")
+(depends-on "annalist")
+
+(development
+ (depends-on "f")
+ (depends-on "ert-runner")
+ (depends-on "package-lint")
+ (depends-on "magit"))
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432
+
+(add-hook 'eask-before-compile-hook
+           (lambda (&rest _)
+             (setq evil-want-integration nil)
+             (setq evil-want-keybinding nil)
+             (setq byte-compile-docstring-max-column 200)
+             (setq byte-compile-error-on-warn t)))
+
+(add-hook 'eask-before-lint/package-hook
+           (lambda (&rest _)
+             (advice-add 'package-lint--check-eval-after-load :around 'ignore)
+             (advice-add 'package-lint--check-version-regexp-list :around 'ignore)
+             (advice-add 'package-lint--check-symbol-separators :around 'ignore)
+             (advice-add 'package-lint--check-defs-prefix :around 'ignore)
+             (advice-add 'package-lint--check-provide-form :around 'ignore)))

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,23 @@
-EMACS ?= emacs
-CASK ?= cask
-
-LOADPATH = -L .
-TESTPATH = -L ./test
-
-ELPA_DIR = \
-	.cask/$(shell $(EMACS) -Q --batch --eval '(princ emacs-version)')/elpa
+EASK ?= eask
 
 compile:
-	$(CASK) exec $(EMACS) -Q -batch							\
-	-L .										\
-	--eval "(setq evil-want-integration nil)"					\
-	--eval "(setq evil-want-keybinding nil)"					\
-	--eval "(setq byte-compile-docstring-max-column 200)"				\
-	--eval "(setq byte-compile-error-on-warn t)"					\
-	-f batch-byte-compile *.el modes/*/*.el
+	$(EASK) compile
+
+install:
+	$(EASK) install-deps --dev
+	$(EASK) package
+	$(EASK) install
 
 lint:
-	$(CASK) exec $(EMACS) -Q -batch							\
-	--eval "(require 'package)"							\
-	--eval "(push '(\"melpa\" . \"http://melpa.org/packages/\") package-archives)"	\
-	--eval "(package-initialize)"							\
-	--eval "(package-refresh-contents)"						\
-	-l package-lint.el								\
-	--eval "(advice-add 'package-lint--check-eval-after-load :around 'ignore)"	\
-	--eval "(advice-add 'package-lint--check-version-regexp-list :around 'ignore)"	\
-	--eval "(advice-add 'package-lint--check-symbol-separators :around 'ignore)"	\
-	--eval "(advice-add 'package-lint--check-defs-prefix :around 'ignore)"		\
-	--eval "(advice-add 'package-lint--check-provide-form :around 'ignore)"		\
-	-f package-lint-batch-and-exit *.el modes/*/*.el
+	$(EASK) lint package
 
-test: elpa
-	$(CASK) exec $(EMACS) -Q -batch $(LOADPATH) $(TESTPATH) \
--l evil-collection-test.el -l evil-collection-magit-tests.el -f ert-run-tests-batch-and-exit
+test: install
+	$(EASK) test ert ./test/evil-collection-test.el
 
-magit-test: elpa
-	$(CASK) exec $(EMACS) -Q -batch $(LOADPATH) $(TESTPATH) \
--l evil-collection-magit-tests.el -f ert-run-tests-batch-and-exit
+magit-test: install
+	$(EASK) test ert ./test/evil-collection-magit-tests.el
 
-elpa: $(ELPA_DIR)
-$(ELPA_DIR): Cask
-	$(CASK) install
-	mkdir -p $(ELPA_DIR)
-	touch $@
-
-.PHONY: compile lint test elpa
+.PHONY: compile lint test
 
 # Local Variables:
 # tab-width: 8

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ compile:
 
 install:
 	$(EASK) install-deps --dev
-	$(EASK) package
-	$(EASK) install
 
 lint:
 	$(EASK) lint package

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -684,7 +684,8 @@ NAME specifies the name of the entry added to HOOK.  If APPEND is
 non-nil, the entry is appended to the hook.  If LOCAL is non-nil,
 the buffer-local value of HOOK is modified.
 
-This is a backport of `evil-delay' without the deprecation notice to deal with CI until migration can be done.
+This is a backport of `evil-delay' without the deprecation notice to deal with
+CI until migration can be done.
 Ref: https://github.com/emacs-evil/evil-collection/issues/750"
   (eval `(evil-with-delay ,condition (,hook ,append ,local ,name) ,form) t))
 

--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -200,7 +200,8 @@ Move `magit-diff-default-context' to \"~\"."
     (evil-set-initial-state mode evil-default-state)))
 
 (defun evil-collection-magit-revert-initial-states ()
-  "Revert the initial state for modes to their values before evil-collection-magit was loaded."
+  "Revert the initial state for modes to their values before
+evil-collection-magit was loaded."
   (dolist (mode (append evil-collection-magit-emacs-to-evil-collection-magit-state-modes
                         evil-collection-magit-emacs-to-default-state-modes))
     (evil-set-initial-state mode 'emacs))
@@ -635,9 +636,9 @@ evil-collection-magit affects.")
 ;;;###autoload
 (defun evil-collection-magit-init ()
   "This function completes the setup of evil-collection-magit. It is called
-automatically when evil-collection-magit-setup is called.. The only reason to use
-this function is if you've called `evil-collection-magit-revert' and wish to
-go back to evil-collection-magit behavior."
+automatically when evil-collection-magit-setup is called.. The only reason to
+use this function is if you've called `evil-collection-magit-revert' and wish
+to go back to evil-collection-magit behavior."
   (interactive)
   (evil-collection-magit-adjust-section-bindings)
   (evil-collection-magit-adjust-popups)

--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -66,6 +66,7 @@
 ;;; Code:
 
 (require 'evil-collection)
+(require 'message)
 (require 'mu4e nil t)
 
 (defvar mu4e-mu-version)


### PR DESCRIPTION
Cask is deprecated and doesn't support Windows. [Eask](https://github.com/emacs-eask/cli) is the new replacement for Cask.

This patch does the following:

1. Add test for macOS and Windows
2. Clean up most `Makefile` logic to Eask-file


