### PR TITLE
replace: Bind q to quit-window when not editing

### DIFF
--- a/modes/replace/evil-collection-replace.el
+++ b/modes/replace/evil-collection-replace.el
@@ -58,6 +58,7 @@
     (kbd "C-k") 'previous-error-no-select
     "r" 'occur-rename-buffer
     "c" 'clone-buffer
+    "q" 'quit-window
     (kbd "C-c C-f") 'next-error-follow-minor-mode)
 
   (evil-collection-define-key 'normal 'occur-edit-mode-map


### PR DESCRIPTION
q is bound by default to dismiss the window, which is useful when
occur is being used only to navigate occurrences and not edit them.