### PR TITLE
kmacro: initial support

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -238,6 +238,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     info
     ivy
     js2-mode
+    ,@(when (>= emacs-major-version 30) '(kmacro))
     leetcode
     lispy
     lms

--- a/modes/kmacro/evil-collection-kmacro.el
+++ b/modes/kmacro/evil-collection-kmacro.el
@@ -1,0 +1,58 @@
+;;; evil-collection-kmacro.el --- Evil bindings for kmacro menu -*- lexical-binding: t -*-
+
+;; Copyright (C) 2024 Zhiwei Chen
+
+;; Author: Zhiwei Chen <condy0919@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "30"))
+;; Keywords: evil, kmacro, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil bindings for kmacro menu.
+
+;;; Code:
+
+(require 'evil-collection)
+(require 'kmacro)
+
+(defconst evil-collection-kmacro-maps '(kmacro-menu-mode-map))
+
+(defun evil-collection-kmacro-setup ()
+  "Set up `evil' bindings to `tab-bar'."
+  (evil-set-initial-state 'kmacro-menu-mode 'normal)
+  (evil-collection-define-key 'normal 'kmacro-menu-mode-map
+    ;; Edit
+    (kbd "RET") 'kmacro-menu-edit-column
+    "#" 'kmacro-menu-edit-position
+    "c" 'kmacro-menu-edit-counter
+    "f" 'kmacro-menu-edit-format
+    "e" 'kmacro-menu-edit-keys
+
+    ;; Mark
+    "d" 'kmacro-menu-flag-for-deletion
+    "m" 'kmacro-menu-mark
+    "u" 'kmacro-menu-unmark
+    "U" 'kmacro-menu-unmark-all
+
+    "x" 'kmacro-menu-do-flagged-delete
+    "C" 'kmacro-menu-do-copy
+    "D" 'kmacro-menu-do-delete))
+
+(provide 'evil-collection-kmacro)
+;;; evil-collection-kmacro.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

Initial support

### Direct link to the package repository

The builtin kmacro.

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
