### PR TITLE
mu4e: fix broken tab navigation in mu4e-view-mode

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -235,8 +235,8 @@ end of the buffer."
 
       (mu4e-view-mode-map
        " " mu4e-view-scroll-up-or-next
-       [tab] shr-next-link
-       [backtab] shr-previous-link
+       [tab] forward-button
+       [backtab] backward-button
        "q" mu4e-view-quit
        "gx" mu4e-view-go-to-url
        "gX" mu4e-view-fetch-url


### PR DESCRIPTION
Before mu4e-1.7.0, using SHR to render HTML emails in mu4e-view-mode was an option. This was removed in mu4e-1.7.0, and mu4e-view-mode now uses Gnus to render HTML emails. This change broke Evil Collection's tab navigation in mu4e-view-mode.