### PR TITLE
Replace specific functions with `mu4e-user-agent` properties

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -222,8 +222,8 @@ end of the buffer."
        "G" mu4e-compose-goto-bottom
        "ZD" message-dont-send
        "ZF" mml-attach-file
-       "ZQ" mu4e-message-kill-buffer
-       "ZZ" message-send-and-exit)
+       "ZQ" ,(function-get 'mu4e-user-agent 'abortfunc)
+       "ZZ" ,(function-get 'mu4e-user-agent 'sendfunc))
 
       (mu4e-search-minor-mode-map
        "J" mu4e-search-maildir)


### PR DESCRIPTION
`mu4e-message-kill-buffer` was replaced with `message-kill-buffer` in mu4e `1.12.*` at 
https://github.com/djcb/mu/commit/20878c872576b2711d43711194f3db0bc86566f4 

This commit replace specific functions with `mu4e-user-agent` properties to make it work for both versions.
