### PR TITLE
diff-mode: disable single-letter cmds w/o respect to selection in "visual"

### DIFF
--- a/modes/diff-mode/evil-collection-diff-mode.el
+++ b/modes/diff-mode/evil-collection-diff-mode.el
@@ -103,6 +103,13 @@ current file instead."
 
     "q" 'quit-window
 
+    "a" 'diff-apply-hunk
+    "*" 'diff-refine-hunk
+    "D" 'diff-file-kill
+    "d" 'diff-hunk-kill
+    "s" 'diff-split-hunk
+    "c" 'diff-test-hunk
+
     "\\" 'read-only-mode) ; magit has "\"
 
   (evil-collection-define-key 'motion 'diff-mode-map
@@ -119,17 +126,10 @@ current file instead."
     (kbd "RET") 'diff-goto-source
     "A" 'diff-add-change-log-entries-other-window
 
-    "a" 'diff-apply-hunk
-    "*" 'diff-refine-hunk
-    "D" 'diff-file-kill
-    "d" 'diff-hunk-kill
-
     "ge" 'diff-ediff-patch
     "i" 'next-error-follow-minor-mode
     "o" 'evil-collection-diff-toggle-restrict-view
     "~" 'diff-reverse-direction
-    "s" 'diff-split-hunk
-    "c" 'diff-test-hunk
     "x" 'evil-collection-diff-toggle-context-unified
     "#" 'diff-ignore-whitespace-hunk
 


### PR DESCRIPTION
As mentioned in the original issue, the keybinding is confusing and problematic. There has been no opposing comments for 1.5 months, so let's go ahead and ~~remove~~ make it to only work in `normal`.

Fixes: https://github.com/emacs-evil/evil-collection/issues/810