### PR TITLE
Update mpdired keybinding to the new funtions

### DIFF
--- a/modes/mpdired/evil-collection-mpdired.el
+++ b/modes/mpdired/evil-collection-mpdired.el
@@ -50,14 +50,15 @@
     "k"         'mpdired-previous-line
     (kbd "RET") 'mpdired-enter
     "^"         'mpdired-goto-parent
+    "."         'mpdired-goto-current-song
     "o"         'mpdired-toggle-view
-    "g r"       'mpdired-update
-    "g R"       'mpdired-db-update
+    "gr"        'mpdired-update
+    "gR"        'mpdired-db-update
     "J"         'mpdired-next-internal
     "K"         'mpdired-previous-internal
     "a"         'mpdired-add
     "d"         'mpdired-flag-at-point
-    "x"         'mpdired-flagged-delete
+    "x"         'mpdired-execute
     "D"         'mpdired-delete
     "p"         'mpdired-pause-internal
     (kbd "SPC") 'mpdired-pause-internal
@@ -76,7 +77,9 @@
     "t"         'mpdired-toggle-marks
     "T"         'mpdired-previous-unmark
     "%d"        'mpdired-flag-files-regexp
-    "%m"        'mpdired-mark-files-regexp))
+    "%m"        'mpdired-mark-files-regexp
+    "%i"        'mpdired-put-order-at-point
+    "%r"        'mpdired-put-order-at-point))
 
 (provide 'evil-collection-mpdired)
 ;;; evil-collection-mpdired.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/your/awesome_package

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
