### PR TITLE
magit: Separate mode for magit-repos

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -252,6 +252,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     macrostep
     man
     (magit magit-submodule) ;; See https://github.com/emacs-evil/evil-collection/issues/637
+    magit-repos
     magit-section
     magit-todos
     markdown-mode

--- a/modes/magit-repos/evil-collection-magit-repos.el
+++ b/modes/magit-repos/evil-collection-magit-repos.el
@@ -1,0 +1,49 @@
+;;; evil-collection-magit-repos.el --- Bindings for magit-repos -*- lexical-binding: t -*-
+
+;; Copyright (C) 2015-2016, 2021 Justin Burkett
+
+;; Author: Justin Burkett <justin@burkett.cc>
+;; Maintainer: Justin Burkett <justin@burkett.cc>
+;; James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; Package-Requires: ((emacs "26.3") (evil "1.2.3") (magit "2.6.0"))
+;; Homepage: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation; either version 3, or (at your
+;; option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; For a full copy of the GNU General Public License
+;; see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for magit-repos.
+
+;;; Code:
+(require 'evil-collection)
+(require 'magit-repos nil t)
+
+(defvar magit-repolist-mode-map)
+(defconst evil-collection-magit-repos-maps '(magit-repolist-mode-map))
+
+;;;###autoload
+(defun evil-collection-magit-repos-setup ()
+  "Set up `evil' bindings for `magit-repos'."
+  (evil-set-initial-state 'magit-repolist-mode 'normal)
+  (evil-collection-define-key 'normal 'magit-repolist-mode-map
+    "m" 'magit-repolist-mark
+    "u" 'magit-repolist-unmark
+    "f" 'magit-repolist-fetch
+    (kbd "RET") 'magit-repolist-status
+    (kbd "gr")  'magit-list-repositories)
+  (add-hook 'magit-repolist-mode-hook 'evil-normalize-keymaps))
+
+(provide 'evil-collection-magit-repos)
+;;; evil-collection-magit-repos.el ends here

--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -50,7 +50,6 @@
 (defvar magit-process-mode-map)
 (defvar magit-reflog-mode-map)
 (defvar magit-refs-mode-map)
-(defvar magit-repolist-mode-map)
 (defvar magit-status-mode-map)
 (defvar magit-submodule-list-mode-map)
 
@@ -62,7 +61,6 @@
     magit-blame-read-only-mode-map
     magit-blob-mode-map
     magit-submodule-list-mode-map ; -> parent: `magit-repolist-mode-map'
-    magit-repolist-mode-map
     magit-mode-map))
 
 (defcustom evil-collection-magit-use-y-for-yank t
@@ -475,15 +473,6 @@ denotes the original magit key for this command.")
 
 ;; Need to refresh evil keymaps when blame mode is entered.
 (add-hook 'magit-blame-mode-hook 'evil-normalize-keymaps)
-
-(evil-set-initial-state 'magit-repolist-mode 'normal)
-(evil-collection-define-key 'normal 'magit-repolist-mode-map
-  "m" 'magit-repolist-mark
-  "u" 'magit-repolist-unmark
-  "f" 'magit-repolist-fetch
-  (kbd "RET") 'magit-repolist-status
-  (kbd "gr")  'magit-list-repositories)
-(add-hook 'magit-repolist-mode-hook 'evil-normalize-keymaps)
 
 (evil-set-initial-state 'magit-submodule-list-mode 'normal)
 (evil-collection-define-key 'normal 'magit-submodule-list-mode-map


### PR DESCRIPTION
The fix for https://github.com/emacs-evil/evil-collection/issues/637 reintroduced the problem reported in https://github.com/emacs-evil/evil-collection/issues/510.

This PR extracts magit-repos bindings from magit mode by creating a new separate mode. This should make possible to load correctly magit-repos bindings without interfering with magit main bindings loading process.