### PR TITLE
Hyrolo

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -229,6 +229,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     helpful
     hg-histedit
     hungry-delete
+    hyrolo
     ibuffer
     (image image-mode)
     image-dired

--- a/modes/hyrolo/evil-collection-hyrolo.el
+++ b/modes/hyrolo/evil-collection-hyrolo.el
@@ -10,6 +10,11 @@
 (defvar hyrolo-mode-map)
 (defconst evil-collection-hyrolo-maps '(hyrolo-mode-map))
 
+(declare-function hyrolo-to-previous-loc "hyrolo")
+(declare-function hyrolo-to-next-loc "hyrolo")
+(declare-function hyrolo-overview "hyrolo")
+(declare-function hyrolo-outline-show-all "hyrolo")
+
 (defun evil-collection-hyrolo-setup ()
   "Set up `evil' bindings for hyrolo."
   (evil-collection-define-key 'normal 'hyrolo-mode-map

--- a/modes/hyrolo/evil-collection-hyrolo.el
+++ b/modes/hyrolo/evil-collection-hyrolo.el
@@ -15,13 +15,12 @@
   (evil-collection-define-key 'normal 'hyrolo-mode-map
     (kbd "[[") #'hyrolo-to-previous-loc
     (kbd "]]") #'hyrolo-to-next-loc
-    (kbd "C-j") #'hyrolo-to-previous-loc
-    (kbd "C-k") #'hyrolo-to-next-loc
-    (kbd "gj") #'hyrolo-to-previous-loc
-    (kbd "gk") #'hyrolo-to-next-loc
+    (kbd "C-k") #'hyrolo-to-previous-loc
+    (kbd "C-j") #'hyrolo-to-next-loc
+    (kbd "gk") #'hyrolo-to-previous-loc
+    (kbd "gj") #'hyrolo-to-next-loc
     (kbd "zo") #'hyrolo-outline-show-all
-    (kbd "zc") #'hyrolo-overview
-    ))
+    (kbd "zc") #'hyrolo-overview))
 
 (provide 'evil-collection-hyrolo)
 ;;; evil-collection-hyrolo.el ends here

--- a/modes/hyrolo/evil-collection-hyrolo.el
+++ b/modes/hyrolo/evil-collection-hyrolo.el
@@ -20,7 +20,8 @@
     (kbd "gk") #'hyrolo-to-previous-loc
     (kbd "gj") #'hyrolo-to-next-loc
     (kbd "zo") #'hyrolo-outline-show-all
-    (kbd "zc") #'hyrolo-overview))
+    (kbd "zc") #'hyrolo-overview)
+  (evil-set-initial-state 'hyrolo-mode 'normal))
 
 (provide 'evil-collection-hyrolo)
 ;;; evil-collection-hyrolo.el ends here

--- a/modes/hyrolo/evil-collection-hyrolo.el
+++ b/modes/hyrolo/evil-collection-hyrolo.el
@@ -7,8 +7,8 @@
 (require 'evil-collection)
 (require 'hyperbole nil t)
 
-(defvar eldoc-mode-map)
-(defconst evil-collection-eldoc-maps '(hyrolo-mode-map))
+(defvar hyrolo-mode-map)
+(defconst evil-collection-hyrolo-maps '(hyrolo-mode-map))
 
 (defun evil-collection-hyrolo-setup ()
   "Set up `evil' bindings for hyrolo."

--- a/modes/hyrolo/evil-collection-hyrolo.el
+++ b/modes/hyrolo/evil-collection-hyrolo.el
@@ -1,0 +1,27 @@
+;;; evil-collection-hyrolo.el --- Bindings for `hyrolo' -*- lexical-binding: t -*-
+
+;;; Commentary:
+;;; Bindings for hyrolo.
+
+;;; Code:
+(require 'evil-collection)
+(require 'hyperbole nil t)
+
+(defvar eldoc-mode-map)
+(defconst evil-collection-eldoc-maps '(hyrolo-mode-map))
+
+(defun evil-collection-hyrolo-setup ()
+  "Set up `evil' bindings for hyrolo."
+  (evil-collection-define-key 'normal 'hyrolo-mode-map
+    (kbd "[[") #'hyrolo-to-previous-loc
+    (kbd "]]") #'hyrolo-to-next-loc
+    (kbd "C-j") #'hyrolo-to-previous-loc
+    (kbd "C-k") #'hyrolo-to-next-loc
+    (kbd "gj") #'hyrolo-to-previous-loc
+    (kbd "gk") #'hyrolo-to-next-loc
+    (kbd "zo") #'hyrolo-outline-show-all
+    (kbd "zc") #'hyrolo-overview
+    ))
+
+(provide 'evil-collection-hyrolo)
+;;; evil-collection-hyrolo.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

hyrolo is part of hyperbole, basically a record manager

### Direct link to the package repository

https://www.gnu.org/software/hyperbole/

### Checklist

<!-- Please confirm with `x`: -->
I dont know how to check "byte-compiles cleanly", but should be fine ?

Assume you're working on `mpc` mode:

- [? ] byte-compiles cleanly
- [ x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [ x] define `evil-collection-mpc-mode-maps` with `defconst`
- [ x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
