### PR TITLE
Make magit-toggle-text-mode work in git-rebase-mode buffers

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -654,6 +654,9 @@ using `evil-collection-magit-toggle-text-mode'"
 (evil-collection-define-key evil-collection-magit-state 'magit-mode-map
   "\C-t" 'evil-collection-magit-toggle-text-mode
   "\\"   'evil-collection-magit-toggle-text-mode)
+(evil-collection-define-key evil-collection-magit-state 'git-rebase-mode-map
+  "\C-t" 'evil-collection-magit-toggle-text-mode
+  "\\"   'evil-collection-magit-toggle-text-mode)
 
 (defvar evil-collection-magit-last-mode nil
   "Used to store last magit mode before entering text mode using
@@ -662,10 +665,11 @@ using `evil-collection-magit-toggle-text-mode'"
 (defun evil-collection-magit-toggle-text-mode ()
   "Switch to `text-mode' and back from magit buffers."
   (interactive)
-  (cond ((derived-mode-p 'magit-mode)
+  (cond ((derived-mode-p 'magit-mode 'git-rebase-mode)
          (setq evil-collection-magit-last-mode major-mode)
          (message "Switching to text-mode")
          (text-mode)
+         (read-only-mode -1)
          (evil-collection-magit-toggle-text-minor-mode 1)
          (evil-normalize-keymaps))
         ((and (eq major-mode 'text-mode)


### PR DESCRIPTION
`evil-collection-magit-toggle-text-mode` currently doesn't work in `git-rebase-mode` buffers, as the `cond` checks only for `'magit-mode`. Thus the function just shows the error "evil-collection-magit-toggle-text-mode unexpected state" if invoked in a `git-rebase-mode` buffer. The `C-t` and `\` bindings are also not set while in this mode.

These changes make `evil-collection-magit-toggle-text-mode` also work in `git-rebase-mode`, and set up the same key bindings in this mode. Because `git-rebase-mode` also enables `read-only-mode` in the buffer, we need to disable that too when switching to `text-mode`.