### PR TITLE
Gnus: add gnus-summary-browse-url binding

### DIFF
--- a/modes/gnus/evil-collection-gnus.el
+++ b/modes/gnus/evil-collection-gnus.el
@@ -122,6 +122,7 @@ Note that there is no gnus-common-mode-map")
     "z/"        'gnus-summary-limit-map
     "zt"        'gnus-summary-toggle-header
     "x"         'gnus-summary-limit-to-unread
+    "gX"        'gnus-summary-browse-url
 
     ;; Finding the parent
     "^"         'gnus-summary-refer-parent-article


### PR DESCRIPTION
**Function**: gnus-summary-browse-url
**Default binding**: 'w'
**Proposed binding**: 'gX'
**Rationale**: This same Vim-like binding already exists in the package, but only for the article-mode/map. This addition enables a more dynamic workflow allowing users to open articles' URLs directly from summary-mode, as  ̶G̶o̶d̶ ̶i̶n̶t̶e̶n̶d̶e̶d̶ the function name describes.

_For the record, I personally have overridden this and other bindings in this module to match the Gnus defaults in my configuration, some of them create less friction IMO. However, I believe I will eventually get used to the choices made by the collection, coming from a Gnus/Emacs defaults background. The more I learn Vim and consider the collections' changes/choices for Gnus, the more they make sense :smile:  (Anyways, I digress)._
