### PR TITLE
Fix link to Doom Emacs reference (another readme update PR, sorry)

### DIFF
--- a/README.org
+++ b/README.org
@@ -629,7 +629,7 @@ file an issue.
 Other references:
 
 - [[https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.org#key-bindings-conventions][Spacemacs]]
-- [[https://github.com/hlissner/doom-emacs/tree/develop/modules/editor/evil][Doom Emacs]]
+- [[https://github.com/doomemacs/doomemacs/tree/master/modules/editor/evil][Doom Emacs]]
 
 ** FAQ
 


### PR DESCRIPTION
### Brief summary

Just found broken url. You can commit it yourself and discard the PR, so that I don't get on the list of contributors. I am okey with it. I don't want to be in the list because nothing special / or functional in this pr. 