### PR TITLE
Gnus: fix gnus-group next and prev inconsistency

### DIFF
--- a/modes/gnus/evil-collection-gnus.el
+++ b/modes/gnus/evil-collection-gnus.el
@@ -320,6 +320,8 @@ Note that there is no gnus-common-mode-map")
     "]]"        'gnus-group-next-unread-group
     "gk"        'gnus-group-prev-unread-group
     "gj"        'gnus-group-next-unread-group
+    (kbd "C-j") 'gnus-group-next-group
+    (kbd "C-k") 'gnus-group-prev-group
 
     ;; Composing, like mu4e
     "C"         'gnus-group-mail


### PR DESCRIPTION
**Function**: `gnus-group-next-group`, `gnus-group-prev-group`
**Default binding**: 'N', 'P'
**Proposed binding**: 'C-j', 'C-k'
**Rationale**: These same bindings, 'C-j'  and 'C-k', already exist for similar movements in `gnus-summary-mode-map` and  in other modes such as  org and magit . This addition makes the Gnus bindings more consistent within Gnus modes and across other modes/maps in the package. It also prevents users from accidentally removing a topic with default 'C-k' (gnus-topic-kill-group) while expecting to perform an evil movement action. 

