### PR TITLE
remove `(defvar mu4e-mu-version)`

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -69,7 +69,6 @@
 (require 'message)
 (require 'mu4e nil t)
 
-(defvar mu4e-mu-version)
 (declare-function evil-collection-mu4e-set-bindings "evil-collection-mu4e")
 (declare-function evil-collection-mu4e-set-state "evil-collection-mu4e")
 (declare-function mu4e-headers-mark-thread "mu4e-headers")


### PR DESCRIPTION
Without this change evil-collection fails to pick up the mu4e-mu-version set in the mu4e module.

I'm new to emacs lisp but I think we're overriding the `mu4e-mu-version` variable set in the mu4e module with one set in this module to `nil`.

Any feedback or advice is welcome if this is the wrong solution.