### PR TITLE
fix(view-mode): use `#'View-quit`

### DIFF
--- a/modes/view/evil-collection-view.el
+++ b/modes/view/evil-collection-view.el
@@ -38,7 +38,7 @@
   (add-hook 'view-mode-hook 'evil-normalize-keymaps)
   (evil-set-initial-state 'view-mode 'normal)
   (evil-collection-define-key 'normal 'view-mode-map
-    "q" 'quit-window
+    "q" 'View-quit
     (kbd "SPC") 'View-scroll-page-forward
     (kbd "S-SPC") 'View-scroll-page-backward
 


### PR DESCRIPTION
view-mode itself recommends using this function to quit the mode in
in a message in its source code:

```
View mode: type \\[help-command] for help, \\[describe-mode] for commands, \\[View-quit] to quit.
```

Using `#'quit-window` does not work as expected when viewing a diff using view-mode for a buffer in a save prompt in magit: `#'quit-window` breaks the prompting sequence, whilst `#'View-quit` doesn't.