### PR TITLE
Org: Date movement for calendar date selection in minibuffer

### DIFF
--- a/modes/org/evil-collection-org.el
+++ b/modes/org/evil-collection-org.el
@@ -24,12 +24,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; Evil basic bindings for org-mode. It's NOT intended to supersede
+;; Evil basic bindings for org-mode.  It's NOT intended to supersede
 ;; `evil-org-mode'.
 ;;
 
 ;;; Code:
 (require 'evil-collection)
+(require 'org nil t)
+
 
 (defconst evil-collection-org-maps '(org-mode-map
                                      org-capture-mode-map
@@ -52,6 +54,7 @@
 (declare-function org-calendar-backward-month "org")
 (declare-function org-calendar-forward-year "org")
 (declare-function org-calendar-backward-year "org")
+(declare-function org-defkey "org")
 
 ;;;###autoload
 (defun evil-collection-org-setup ()

--- a/modes/org/evil-collection-org.el
+++ b/modes/org/evil-collection-org.el
@@ -32,7 +32,8 @@
 (require 'evil-collection)
 
 (defconst evil-collection-org-maps '(org-mode-map
-                                     org-capture-mode-map))
+                                     org-capture-mode-map
+                                     org-read-date-minibuffer-local-map))
 
 (declare-function org-shifttab "org")
 (declare-function org-backward-paragraph "org")
@@ -42,6 +43,15 @@
 (declare-function org-capture-finalize "org-capture")
 (declare-function org-capture-kill "org-capture")
 (declare-function org-capture-refile "org-capture")
+
+(declare-function org-calendar-forward-day "org")
+(declare-function org-calendar-backward-day "org")
+(declare-function org-calendar-forward-week "org")
+(declare-function org-calendar-backward-week "org")
+(declare-function org-calendar-forward-month "org")
+(declare-function org-calendar-backward-month "org")
+(declare-function org-calendar-forward-year "org")
+(declare-function org-calendar-backward-year "org")
 
 ;;;###autoload
 (defun evil-collection-org-setup ()
@@ -59,7 +69,16 @@
   (evil-collection-define-key 'normal 'org-capture-mode-map
     "ZZ" 'org-capture-finalize
     "ZQ" 'org-capture-kill
-    "ZR" 'org-capture-refile))
+    "ZR" 'org-capture-refile)
+
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-l") #'org-calendar-forward-day)
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-h") #'org-calendar-backward-day)
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-j") #'org-calendar-forward-week)
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-k") #'org-calendar-backward-week)
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-L") #'org-calendar-forward-month)
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-H") #'org-calendar-backward-month)
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-J") #'org-calendar-forward-year)
+  (org-defkey org-read-date-minibuffer-local-map (kbd "M-K") #'org-calendar-backward-year))
 
 (provide 'evil-collection-org)
 ;;; evil-collection-org.el ends here


### PR DESCRIPTION
### Brief summary of what the package does
A [GNU Emacs](https://www.gnu.org/software/emacs/) major mode for keeping notes, authoring documents, computational notebooks, literate programming, maintaining to-do lists, planning projects, and more — in a fast and effective plain text system.

### Direct link to the package repository
https://orgmode.org/

### Changes to existing bindings
When selecting a date in org mode (e.g. using C-c .), by default you select dates using Shift+Arrow keys.
This change will allow you to use M-hjkl/HJKL to move by day, week, month and year directly from the minibuffer.

### Checklist
- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-org-setup` with `defun`
- [x] define `evil-collection-org-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-org-`

### Additional Notes
I did the rebinding with `org-defkey` insted of `evil-collection-define-key` - for some reason, the former works while the latter does not. Let me know if there is a better way.
Closes #816

<!-- After submitting, please fix any problems the CI reports. -->
