### PR TITLE
dired: add keybinding for dired-do-open

### DIFF
--- a/modes/dired/evil-collection-dired.el
+++ b/modes/dired/evil-collection-dired.el
@@ -190,6 +190,10 @@
     ";s" 'epa-dired-do-sign
     ";e" 'epa-dired-do-encrypt)
 
+  (when (>= emacs-major-version 30)
+    (evil-collection-define-key 'normal 'dired-mode-map
+      "E" 'dired-do-open))
+
   ;; dired-x commands
   (with-eval-after-load 'dired-x
     (evil-collection-define-key 'normal 'dired-mode-map


### PR DESCRIPTION
### Brief summary of what the package does

The next Emacs release will come with a new command: `dired-do-open`.

This PR just adds a keybinding for this command in evil `normal` state (same as defined in `emacs` state).

### Direct link to the package repository

Dired is a built-in package.
Link to the new command in NEWS file : https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-30#n1092


### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
