### PR TITLE
vlf: fix keybindings

### DIFF
--- a/modes/vlf/evil-collection-vlf.el
+++ b/modes/vlf/evil-collection-vlf.el
@@ -46,7 +46,9 @@
   "Set up `evil' bindings for `vlf'."
   (evil-set-initial-state 'vlf-mode 'normal)
 
-  (evil-collection-define-key 'normal 'vlf-mode-map
+  (add-hook 'vlf-mode-hook #'evil-normalize-keymaps)
+
+  (evil-collection-define-key 'normal 'vlf-prefix-map
     "gj" 'vlf-next-batch
     "gk" 'vlf-prev-batch
     (kbd "C-j") 'vlf-next-batch


### PR DESCRIPTION
Confusingly, [`vlf-mode-map` and `vlf-prefix-map`](https://git.savannah.gnu.org/gitweb/?p=emacs/elpa.git;a=blob;f=vlf.el;h=ae918e0309af045dec9d9838f63437237d24cbc5;hb=refs/heads/externals/vlf#l79) are the opposite of what they sound like, so to apply the keybindings without a prefix, they need to go in `vlf-prefix-map`.

`evil-normalize-keymaps` seems to also be needed for the keybindings to work.

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you

<!-- After submitting, please fix any problems the CI reports. -->
