### PR TITLE
emms: Replace emms-browser-delete-files with non-disabled alias

### DIFF
--- a/modes/emms/evil-collection-emms.el
+++ b/modes/emms/evil-collection-emms.el
@@ -143,7 +143,7 @@ The return value is the yanked text."
 
 
     "C" 'emms-browser-clear-playlist
-    "D" 'emms-browser-delete-files
+    "D" 'emms-browser-remove-tracks
     "d" 'emms-browser-view-in-dired
     ;; "d" does the same, keep "gd" for consistency.
     "gd" 'emms-browser-view-in-dired)


### PR DESCRIPTION
`emms-browser-delete-files` is defined as an identical alias of `emms-browser-remove-tracks`, and the former is disabled by default.

The interactive functionality of the two is:
- without prefix argument, only removes tracks from the browser view and clean the cache respectively
- with prefix argument, delete the file too

So it makes more sense to use `emms-browser-remove-tracks` instead, as its name matches its default behavior and also is not disabled.