### PR TITLE
Dashboard: fix function arguments for advice

### DIFF
--- a/modes/dashboard/evil-collection-dashboard.el
+++ b/modes/dashboard/evil-collection-dashboard.el
@@ -34,7 +34,7 @@
 
 (defconst evil-collection-dashboard-maps '(dashboard-mode-map))
 
-(defun evil-collection-dashboard-setup-jump-commands ()
+(defun evil-collection-dashboard-setup-jump-commands (&rest _)
   "Set up bindings for jump commands in Dashboard."
   (evil-collection-define-key 'normal 'dashboard-mode-map
     "r" (symbol-function (lookup-key dashboard-mode-map "r")) ; recents


### PR DESCRIPTION
Arguments expected by 
`dashboard-insert-startupify-lists` have recently changed (see https://github.com/emacs-dashboard/emacs-dashboard/commit/2be75c0ab87a6279ea9840f7c043f7605788d6fb).

So `evil-collection-dashboard-setup-jump-commands` must be adapted accordingly.