### PR TITLE
telega: close chat with quit-window

### DIFF
--- a/modes/telega/evil-collection-telega.el
+++ b/modes/telega/evil-collection-telega.el
@@ -114,7 +114,7 @@
 
     (kbd "RET") 'telega-chatbuf-newline-or-input-send
 
-    "q" 'bury-buffer)
+    "q" 'quit-window)
 
   (evil-collection-define-key 'normal 'telega-image-mode-map
     "ga" telega-prefix-map


### PR DESCRIPTION
`bury-buffer` does not close Telega's chat window, use `quit-window` instead.

### Brief summary of what the package does

N/A

### Direct link to the package repository

https://github.com/zevlg/telega.el/blob/b32bf17d8f3745a69cb808f684881596de592ee5/telega-chat.el#L1659

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [ ] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
