### PR TITLE
fix: the goto-reference in slime-mode only works for global variables.

### DIFF
--- a/modes/slime/evil-collection-slime.el
+++ b/modes/slime/evil-collection-slime.el
@@ -163,7 +163,7 @@
 
   (when evil-collection-want-find-usages-bindings
     (evil-collection-define-key 'normal 'slime-mode-map
-      "gr" 'slime-who-references))
+      "gr" 'slime-edit-uses))
 
   (evil-collection-define-key 'normal 'slime-popup-buffer-mode-map
     ;; quit


### PR DESCRIPTION
### Brief summary of what the package does

Fix the binding of `goto reference` in `slime mode`.
The command `slime-who-references` **is not the proper command** to find the references **on a symbol**.
Actually, the `slime-who-references` only works on **global variables**, it doesn't works for **functions**, **methods** and **class**.
As documented:
```
slime-who-references is an interactive byte-compiled Lisp function in
‘slime.el’.

It is bound to g r, <normal-state> g r, C-c C-w C-r and C-c C-w r.

(slime-who-references SYMBOL)

Show all known referrers of the global variable SYMBOL.

[back]
```

The command `slime-edit-uses` is an all-in-one command, that does combines all the commands to find the references **on a symbol**, including: `a variable`, `a function`, `a method`, `a class`, `a specializer`.

As documented:
```
slime-edit-uses is an interactive byte-compiled Lisp function in
‘slime.el’.

It is bound to M-? and M-_.

(slime-edit-uses SYMBOL)

Lookup all the uses of SYMBOL.

[back]
```

### Direct link to the package repository

https://github.com/slime/slime

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
