### PR TITLE
mpc: add more keybindings and fix original kbd format

### DIFF
--- a/modes/mpc/evil-collection-mpc.el
+++ b/modes/mpc/evil-collection-mpc.el
@@ -47,18 +47,28 @@
 (defun evil-collection-mpc-setup ()
   "Setup up `evil' bindings for `mpc-mode'."
   (evil-collection-define-key 'normal 'mpc-mode-map
-    "C-j" 'evil-collection-mpc-move-down
-    "C-k" 'evil-collection-mpc-move-up
-    "t" 'mpc-toggle-play
-    "r" 'mpc-toggle-repeat
-    "s" 'mpc-toggle-shuffle
-    "c" 'mpc-toggle-consume
-    "p" 'mpc-playlist
-    "a" 'mpc-playlist-add
-    ">" 'mpc-next
-    "<" 'mpc-prev
-    "x" 'mpc-play-at-point
-    "RET" 'mpc-select))
+    (kbd "C-j")        'evil-collection-mpc-move-down
+    (kbd "C-k")        'evil-collection-mpc-move-up
+    "t"                'mpc-toggle-play
+    "r"                'mpc-toggle-repeat
+    "s"                'mpc-toggle-shuffle
+    "c"                'mpc-toggle-consume
+    "gp"               'mpc-playlist
+    "a"                'mpc-playlist-add
+    "J"                'mpc-next
+    "K"                'mpc-prev
+    "x"                'mpc-play-at-point
+    (kbd "RET")        'mpc-select
+    (kbd "S-<return>") 'mpc-select-toggle
+    "go"               'mpc-goto-playing-song
+    "gd"               'mpc-describe-song
+    "p"                'mpc-pause
+    "gs"               'mpc-seek-current
+    "gb"               'mpc-tagbrowser
+    "g/"               'mpc-songs-search
+    "gR"               'mpc-update
+    "gr"               'mpc-current-refresh
+    "q"                'mpc-quit))
 
 (provide 'evil-collection-mpc)
 ;;; evil-collection-mpc.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

Wrap some keybindings in kbd for fixing and add more.

### Direct link to the package repository

this one is emacs builtin.

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [ ] byte-compiles cleanly
- [ ] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
