### PR TITLE
Add ultra-scroll

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -328,6 +328,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     trashed
     tuareg
     typescript-mode
+    ultra-scroll
     vc-annotate
     vc-dir
     vc-git

--- a/modes/ultra-scroll/evil-collection-ultra-scroll.el
+++ b/modes/ultra-scroll/evil-collection-ultra-scroll.el
@@ -1,0 +1,58 @@
+;;; evil-collection-ultra-scroll.el --- Evil integration for ultra-scroll -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 Steven Allen
+
+;; Author: Steven Allen <steven@stebalien.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; Pierre Neidhardt <mail@ambrevar.xyz>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "27.1"))
+;; Keywords: evil, ultra-scroll, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil integration for ultra-scroll.
+
+;;; Code:
+
+(require 'evil-collection)
+(require 'ultra-scroll nil t)
+
+(defvar evil-collection-ultra-scroll-hide-cursor-states
+  '(evil-motion-state-cursor evil-normal-state-cursor)
+  "States in which to hide the cursor when scrolling.")
+
+(defun evil-collection-ultra-scroll--hide-cursor ()
+  "A special Evil cursor type that simply hides the cursor."
+  (setq cursor-type nil))
+
+(defun evil-collection-ultra-scroll--set-cursor-visible (arg)
+  "Make the cursor invisible when called with ARG < 1, or visible otherwise."
+  (when (bound-and-true-p evil-local-mode)
+    (if (and (numberp arg) (< arg 1))
+        (dolist (var evil-collection-ultra-scroll-hide-cursor-states)
+          (make-local-variable var)
+          (set var #'evil-collection-ultra-scroll--hide-cursor))
+      (mapc #'kill-local-variable evil-collection-ultra-scroll-hide-cursor-states)
+      (evil-refresh-cursor))))
+
+(defun evil-collection-ultra-scroll-setup ()
+  "Set up `evil' integration for `ultra-scroll'."
+  (add-hook 'ultra-scroll-hide-functions #'evil-collection-ultra-scroll--set-cursor-visible))
+
+(provide 'evil-collection-ultra-scroll)
+
+;;; evil-collection-ultra-scroll.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

`ultra-scroll` provides significantly improved smooth scrolling over the built-in `pixel-scroll-precision-mode`. It can also hide the cursor, disable `hl-line`, etc. when scrolling. Unfortunately, the "hide cursor" feature doesn't work with Evil because Evil constantly resets the cursor depending on the current state.

This integration hides the cursors for both `motion` and `normal` state when scrolling with `ultra-scroll`.

### Direct link to the package repository

https://github.com/jdtsmith/ultra-scroll

### Checklist

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-ultra-scroll-setup` with `defun`
- [ ] ~define `evil-collection-ultra-scroll-mode-maps` with `defconst`~
- [x] All functions should start with `evil-collection-ultra-scroll-`
