### PR TITLE
fix prefix key collision for mu4e

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -158,8 +158,7 @@ end of the buffer."
        "f" smtpmail-send-queued-mail
        "m" mu4e--main-toggle-mail-sending-mode
        "s" mu4e-search
-       "q" mu4e-quit
-       "c" mu4e-search-query)
+       "q" mu4e-quit)
 
       (mu4e-headers-mode-map
        "q" mu4e~headers-quit-buffer
@@ -216,8 +215,7 @@ end of the buffer."
        "zd" mu4e-headers-toggle-skip-duplicates
        "gl" mu4e-show-log
        "gv" mu4e-select-other-view
-       "T"  evil-collection-mu4e-mark-thread-as-read
-       "c" mu4e-search-query)
+       "T"  evil-collection-mu4e-mark-thread-as-read)
 
       (mu4e-compose-mode-map
        "gg" mu4e-compose-goto-top


### PR DESCRIPTION
This reverts commit 05731c551be8cdda40ae6479adfb30b7e9c7fe39.

This fixes an issue that arises when loading `evil-collection-mu4e`, which gives:

```
Key sequence c c starts with non-prefix key c
```

This occurs for both `mu4e-headers-mode-map` and `mu4e-main-mode-map`.

This should probably just be a different key, but for now I'm just trying to get it unbroken.

cc @RyanGibb for visibility.

Thanks for the wonderful library!

### Checklist

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

