### PR TITLE
Add M-RET binding for compilation mode

### DIFF
--- a/modes/compile/evil-collection-compile.el
+++ b/modes/compile/evil-collection-compile.el
@@ -48,6 +48,8 @@
       (kbd "RET") 'compile-goto-error
 
       "go" 'compilation-display-error
+      (kbd "M-RET") 'compilation-display-error
+      (kbd "M-<return>") 'compilation-display-error
       (kbd "S-<return>") 'compilation-display-error
 
       (kbd "TAB") 'compilation-next-error


### PR DESCRIPTION
### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/your/awesome_package

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [ ] byte-compiles cleanly
- [ ] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [ ] define `evil-collection-mpc-setup` with `defun`
- [ ] define `evil-collection-mpc-mode-maps` with `defconst`
- [ ] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
