### PR TITLE
fix: Warning missing lexical-binding cookie

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "evil-collection"
          "0.0.2"
          "A set of keybindings for Evil mode")


### PR DESCRIPTION
Fix snapshot warning:

```
You can add one with ‘M-x elisp-enable-lexical-binding RET’.
See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’
for more information.
```