### PR TITLE
feat(reftex): Add binding for accepting selection

### DIFF
--- a/modes/reftex/evil-collection-reftex.el
+++ b/modes/reftex/evil-collection-reftex.el
@@ -105,6 +105,7 @@
     (kbd "gk") 'reftex-select-previous-heading
     (kbd "C-j") 'reftex-select-next-heading
     (kbd "C-k") 'reftex-select-previous-heading
+    (kbd "RET") 'reftex-select-accept
     "go" 'reftex-select-callback        ;shows the point where the label is
     "gr" (lambda nil "Press `?' during selection to find out
     about this key" (interactive) (throw (quote myexit) 114)) ;reftex binds keys in a very arcane way using the number asigned by describe-char, in this case the value of "g" is 114


### PR DESCRIPTION
Add a new key binding for the "RET" key to accept the current selection in reftex-select-mode. This improves usability by allowing users to confirm their selection easily.
