### PR TITLE
added shortcut "z L" for hs-minor-mode function "hs-hide-level"

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -231,7 +231,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     help
     helpful
     hg-histedit
-    hs-minor-mode
+    hideshow
     hungry-delete
     hyrolo
     ibuffer

--- a/evil-collection.el
+++ b/evil-collection.el
@@ -231,6 +231,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     help
     helpful
     hg-histedit
+    hs-minor-mode
     hungry-delete
     hyrolo
     ibuffer

--- a/modes/hideshow/evil-collection-hideshow.el
+++ b/modes/hideshow/evil-collection-hideshow.el
@@ -1,4 +1,4 @@
-;;; evil-collection-hs-minor-mode --- Bindings for `hs-minor-mode'  -*- lexical-binding: t; -*-
+;;; evil-collection-hideshow --- Bindings for `hideshow'  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2025 Julian Hoch
 

--- a/modes/hideshow/evil-collection-hideshow.el
+++ b/modes/hideshow/evil-collection-hideshow.el
@@ -1,10 +1,10 @@
 ;;; evil-collection-hs-minor-mode --- Bindings for `hs-minor-mode'  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024 Julian Hoch
+;; Copyright (C) 2025 Julian Hoch
 
 ;; Author: Julian Hoch <julianhoch@web.de>
 ;; Maintainer: Julian Hoch <julianhoch@web.de>
-;; Created: 2024-11-03
+;; Created: 2025-09-27
 ;; Keywords: evil, emacs, tools
 ;; URL: https://github.com/emacs-evil/evil-collection
 
@@ -24,22 +24,22 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Bindings for `hs-minor-mode'.
+;;; Bindings for `hideshow'.
 
 ;;; Code:
 (require 'evil-collection)
-(require 'hs-minor-mode nil t)
+(require 'hideshow nil t)
 
 (declare-function hs-hide-level "hideshow")
 (defvar hs-minor-mode-map)
-(defconst evil-collection-hs-minor-mode-maps '(hs-minor-mode-map))
+(defconst evil-collection-hideshow-maps '(hs-minor-mode-map))
 
 ;;;###autoload
-(defun evil-collection-hs-minor-mode-setup ()
-  "Set up `evil' bindings for `hs-minor-mode'."
+(defun evil-collection-hideshow-setup ()
+  "Set up `evil' bindings for `hideshow'."
   (evil-set-initial-state 'hs-minor-mode 'normal)
   (evil-collection-define-key 'normal 'hs-minor-mode-map
     "zL" 'hs-hide-level))
 
-(provide 'evil-collection-hs-minor-mode)
-;;; evil-collection-hs-minor-mode.el ends here
+(provide 'evil-collection-hideshow)
+;;; evil-collection-hideshow.el ends here

--- a/modes/hs-minor-mode/evil-collection-hs-minor-mode.el
+++ b/modes/hs-minor-mode/evil-collection-hs-minor-mode.el
@@ -1,0 +1,42 @@
+;;; evil-collection-hs-minor-mode --- Bindings for `hs-minor-mode'  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Julian Hoch
+
+;; Author: Julian Hoch <julianhoch@web.de>
+;; Maintainer: Julian Hoch <julianhoch@web.de>
+;; Created: 2024-11-03
+;; Keywords: evil, emacs, tools
+;; URL: https://github.com/emacs-evil/evil-collection
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for `hs-minor-mode'.
+
+;;; Code:
+(require 'evil-collection)
+(require 'hs-minor-mode nil t)
+
+(declare-function hs-hide-level "hideshow")
+
+;;;###autoload
+(defun evil-collection-hs-minor-mode-setup ()
+  "Set up `evil' bindings for `hs-minor-mode'."
+  (evil-collection-define-key 'normal 'hs-minor-mode-map
+    "zL" 'hs-hide-level))
+
+(provide 'evil-collection-hs-minor-mode)
+;;; evil-collection-hs-minor-mode.el ends here

--- a/modes/hs-minor-mode/evil-collection-hs-minor-mode.el
+++ b/modes/hs-minor-mode/evil-collection-hs-minor-mode.el
@@ -31,10 +31,13 @@
 (require 'hs-minor-mode nil t)
 
 (declare-function hs-hide-level "hideshow")
+(defvar hs-minor-mode-map)
+(defconst evil-collection-hs-minor-mode-maps '(hs-minor-mode-map))
 
 ;;;###autoload
 (defun evil-collection-hs-minor-mode-setup ()
   "Set up `evil' bindings for `hs-minor-mode'."
+  (evil-set-initial-state 'hs-minor-mode 'normal)
   (evil-collection-define-key 'normal 'hs-minor-mode-map
     "zL" 'hs-hide-level))
 


### PR DESCRIPTION
### Brief summary of what the package does

hideshow is the built in minor mode for selective display.

### Direct link to the package repository

See: https://www.gnu.org/software/emacs/manual/html_node/emacs/Hideshow.html

### Checklist

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
