### PR TITLE
vundo: hide cursor and hl-line

### DIFF
--- a/modes/vundo/evil-collection-vundo.el
+++ b/modes/vundo/evil-collection-vundo.el
@@ -37,12 +37,29 @@
 
 (defconst evil-collection-vundo-maps '(vundo-mode-map))
 
+(defun evil-collection-vundo--hide-evil-cursor ()
+  "Hide the evil cursor."
+  (setq-local evil-default-cursor    '(nil))
+  (setq-local evil-motion-state-cursor nil)
+  (setq-local evil-visual-state-cursor nil)
+  (setq-local evil-normal-state-cursor nil)
+  (setq-local evil-insert-state-cursor nil)
+  (setq-local evil-emacs-state-cursor  nil))
+
+(defun evil-collection-vundo--disable-hl-line-mode ()
+  "Disable `hl-line-mode'."
+  (setq-local global-hl-line-mode nil))
+
 ;;;###autoload
 (defun evil-collection-vundo-setup ()
   "Set up `evil' bindings for `vundo'."
   (add-hook 'vundo-mode-hook #'evil-normalize-keymaps)
   ;; `vundo' defaults to emacs state.
   (add-hook 'vundo-mode-hook #'evil-normal-state)
+  ;; hide evil cursor
+  (add-hook 'vundo-mode-hook #'evil-collection-vundo--hide-evil-cursor)
+  ;; disable hl-line-mode
+  (add-hook 'vundo-mode-hook #'evil-collection-vundo--disable-hl-line-mode)
 
   (evil-collection-define-key 'normal 'vundo-mode-map
     [remap evil-backward-char] 'vundo-backward


### PR DESCRIPTION
### Brief summary of what the package does

Enhancements to `vundo-mode` UI:

* Added a function (`evil-collection-vundo--hide-evil-cursor`) to hide all Evil cursors locally in `vundo-mode`.
* Added a function (`evil-collection-vundo--disable-hl-line-mode`) to locally disable `hl-line-mode` in `vundo-mode`, removing line highlighting for a cleaner look.
* Updated `evil-collection-vundo-setup` to add both new functions to the `vundo-mode-hook`, ensuring these UI changes are automatically applied whenever `vundo-mode` is activated.

### Direct link to the package repository

https://github.com/casouri/vundo

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `vundo` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-vundo)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-vundo-setup` with `defun`
- [x] define `evil-collection-vundo-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-vundo-`

<!-- After submitting, please fix any problems the CI reports. -->
