### PR TITLE
Add difftastic

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -181,6 +181,7 @@ See `evil-collection-init' and `evil-collection--modes-with-delayed-setup'."
     dictionary
     diff-hl
     diff-mode
+    difftastic
     dired
     dired-sidebar
     disk-usage

--- a/modes/difftastic/evil-collection-difftastic.el
+++ b/modes/difftastic/evil-collection-difftastic.el
@@ -1,0 +1,57 @@
+;;; evil-collection-difftastic.el --- Bindings for `difftastic' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 hiecaq
+
+;; Author: hiecaq <soc.github@hiecaq.org>
+;; Maintainer: hiecaq <soc.github@hiecaq.org>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "26.3"))
+;; Keywords: evil, emacs, convenience, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for difftastic.
+
+;;; Code:
+(require 'evil-collection)
+(require 'difftastic nil t)
+
+(defvar difftastic-mode-map)
+
+(defconst evil-collection-difftastic-maps '(difftastic-mode-map))
+
+;;;###autoload
+(defun evil-collection-difftastic-setup ()
+  "Set up `evil' bindings for `difftastic'."
+  (evil-collection-define-key 'normal 'difftastic-mode-map
+    (kbd "[[") 'difftastic-previous-file
+    (kbd "]]") 'difftastic-next-file
+    (kbd "C-j") 'difftastic-next-chunk
+    (kbd "C-k") 'difftastic-previous-chunk
+    "gj" 'difftastic-next-chunk
+    "gk" 'difftastic-previous-chunk
+    "zc" 'difftastic-hide-chunk
+    "zo" 'difftastic-show-chunk
+    (kbd "TAB") 'difftastic-toggle-chunk
+    (kbd "RET") 'difftastic-diff-visit-file
+    "o" 'difftastic-diff-visit-worktree-file
+    "gr" 'difftastic-rerun
+    "q" 'difftastic-leave
+    "ZQ" 'difftastic-quit))
+
+(provide 'evil-collection-difftastic)
+
+;;; evil-collection-difftastic.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

`difftastic` is a special major mode similar to diff-mode, which integrates the command line tool with the same name.

### Direct link to the package repository

https://github.com/pkryger/difftastic.el

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
