### PR TITLE
eshell: Remove binding to obsolete function eshell-bol

### DIFF
--- a/modes/eshell/evil-collection-eshell.el
+++ b/modes/eshell/evil-collection-eshell.el
@@ -108,8 +108,6 @@ appropriate in some cases like terminals."
     (kbd "C-j") 'eshell-next-prompt
     "gk" 'eshell-previous-prompt
     "gj" 'eshell-next-prompt
-    "0" 'eshell-bol
-    "^" 'eshell-bol
     (kbd "M-h") 'eshell-backward-argument
     (kbd "M-l") 'eshell-forward-argument
 
@@ -123,6 +121,11 @@ appropriate in some cases like terminals."
     "d" 'evil-collection-eshell-evil-delete
     "D" 'evil-collection-eshell-evil-delete-line)
 
+  (when (< emacs-major-version 30)
+    (evil-collection-define-key 'normal 'eshell-mode-map
+      "0" 'eshell-bol
+      "^" 'eshell-bol))
+
   (when evil-want-C-u-delete
     (evil-collection-define-key 'insert 'eshell-mode-map
       (kbd "C-u") 'eshell-kill-input))
@@ -135,9 +138,12 @@ appropriate in some cases like terminals."
     (kbd "C-k") 'eshell-previous-prompt
     (kbd "C-j") 'eshell-next-prompt
     "gk" 'eshell-previous-prompt
-    "gj" 'eshell-next-prompt
-    "0" 'eshell-bol
-    "^" 'eshell-bol)
+    "gj" 'eshell-next-prompt)
+
+  (when (< emacs-major-version 30)
+    (evil-collection-define-key 'visual 'eshell-mode-map
+      "0" 'eshell-bol
+      "^" 'eshell-bol))
 
   (evil-normalize-keymaps)
   (unless evil-collection-always-run-setup-hook-after-load


### PR DESCRIPTION
`eshell-bol` is an obsolete function starting with Emacs 30.1.  See `(view-emacs-news 30.1)`:

> *** Eshell now uses 'field' properties in its output.
> In particular, this means that pressing the '\<home\>' key moves the
> point to the beginning of your input, not the beginning of the whole
> line.  If you want to go back to the old behavior, add something like
> this to your configuration:
>
>     (keymap-set eshell-mode-map "<home>" #'eshell-bol-ignoring-prompt)
>
> This also means you no longer need to adjust 'eshell-prompt-regexp'
> when customizing your Eshell prompt.

With this change in eshell, `evil-beginning-of-line` already moves to the end of the prompt, if there is any. The only difference which might be there is that if the cursor is in column zero of a line which has a prompt, it doesn't move to the end of the prompt, which I think was the old behaviour of `eshell-bol`. But since `eshell-bol` is now a function alias to `beginning-of-line`, it doesn't make any difference if the mapping in evil-collection is present or not.

Currently, the mapping generates a warning on the first usage of `eshell-bol`.