### PR TITLE
magit: Fix :exclude-newline rewriting

### DIFF
--- a/modes/magit/evil-collection-magit.el
+++ b/modes/magit/evil-collection-magit.el
@@ -263,10 +263,10 @@ evil-collection-magit was loaded."
 (defun evil-collection-magit--filter-args-visual-expand-region (arglist)
   ;; pretend that the command has the :exclude-newline property by rewriting the
   ;; EXCLUDE-NEWLINE arg to this function
-  (cons (and (bound-and-true-p evil-collection-magit-in-visual-pre-command)
-             (null (car arglist))
-             (eq (evil-visual-type) 'line)
-             (derived-mode-p 'magit-mode))
+  (cons (or (car arglist)
+            (and (bound-and-true-p evil-collection-magit-in-visual-pre-command)
+                 (eq (evil-visual-type) 'line)
+                 (derived-mode-p 'magit-mode)))
         ;; shouldn't be necessary, but this will prevent it from failing if an
         ;; arg is added.
         (cdr arglist)))


### PR DESCRIPTION
Only rewrite the EXCLUDE-NEWLINE argument when
evil-collection-magit-in-visual-pre-command is t. Previously the code always rewrote the argument to nil even when evil-collection-magit-in-visual-pre-command was not bound.
