### PR TITLE
corfu: Add "<return>" to corfu-map when magic-return is enabled

### DIFF
--- a/modes/corfu/evil-collection-corfu.el
+++ b/modes/corfu/evil-collection-corfu.el
@@ -126,6 +126,9 @@ This key theme variable may be refactored in the future so use with caution."
       "If we made a selection during `corfu' completion, select it.")
     ;; FIXME: Not sure why we need to use `define-key' here instead of
     ;; `evil-collection-define-key';.
+    (when (evil-collection-can-bind-key "<return>")
+          (define-key corfu-map (kbd "<return>")
+            evil-collection-corfu-insert-or-next-line))
     (when (evil-collection-can-bind-key "RET")
       (define-key corfu-map (kbd "RET")
         evil-collection-corfu-insert-or-next-line)))


### PR DESCRIPTION
This ensures the completion candidate is inserted when pressing the Enter key in GUI frames. Previously, only RET was bound, which could cause the key to fall through to the default minibuffer or evil-insert-state binding.
