### PR TITLE
docs(magit): document worktree key in keybindings table

### DIFF
--- a/modes/magit/README.org
+++ b/modes/magit/README.org
@@ -134,7 +134,7 @@
   | reset                  | =x/X=   | =o/O=                  |                       |               |          |
   | show-refs              | =y=     |                        | =yr= (=y= in popup)   |               |          |
   | cherry                 | =Y=     |                        |                       |               |          |
-  | worktree               | =Z=     |                        |                       |               | =%=      |
+  | worktree               | =Z/%=   |                        |                       |               | =%=      |
   | stash                  | =z/Z=   |                        |                       |               | =Z=      |
   | git-cmd                | =:=     | =¦=                    |                       |               |          |
   | run                    | =!=     |                        |                       |               |          |


### PR DESCRIPTION
## Summary
- add a dedicated `worktree` row in the Magit keybindings table
- document default key as `Z`
- document remapped key as `%` when `evil-collection-magit-use-z-for-folds` is enabled

## Why
Users can discover `magit-worktree` in practice (notably on `%` with folds enabled), but this mapping is not explicit in the README table.