### PR TITLE
mu4e: add 'Q' binding to mu4e-search-query

### DIFF
--- a/modes/mu4e/evil-collection-mu4e.el
+++ b/modes/mu4e/evil-collection-mu4e.el
@@ -158,7 +158,8 @@ end of the buffer."
        "f" smtpmail-send-queued-mail
        "m" mu4e--main-toggle-mail-sending-mode
        "s" mu4e-search
-       "q" mu4e-quit)
+       "q" mu4e-quit
+       "Q" mu4e-search-query)
 
       (mu4e-headers-mode-map
        "q" mu4e~headers-quit-buffer
@@ -215,7 +216,8 @@ end of the buffer."
        "zd" mu4e-headers-toggle-skip-duplicates
        "gl" mu4e-show-log
        "gv" mu4e-select-other-view
-       "T"  evil-collection-mu4e-mark-thread-as-read)
+       "T"  evil-collection-mu4e-mark-thread-as-read
+       "Q" mu4e-search-query)
 
       (mu4e-compose-mode-map
        "gg" mu4e-compose-goto-top


### PR DESCRIPTION
mu4e-search-query was introduced in mu4e v1.12.0

bindings are added for the main and headers view