### PR TITLE
Apply the key blacklist to bindings with conflicting prefixes

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -534,6 +534,26 @@ means all states for `evil-define-key', return nil."
        states)
      evil-collection-state-denylist)))
 
+(defun evil-collection--keys-conflict (key-a key-b)
+  "Return t if KEY-A and KEY-B conflict.
+Keys conflict if they're equal or if one is a prefix of the other."
+  (setq key-a (vconcat key-a)
+        key-b (vconcat key-b))
+  (let ((len (min (length key-a) (length key-b))))
+    (equal (substring key-a 0 len) (substring key-b 0 len))))
+
+(defsubst evil-collection--can-bind-key (key whitelist blacklist)
+  "Return t if KEY can be bound.
+Return nil if KEY conflicts with a key in BLACKLIST and is not
+a member of WHITELIST.
+
+Both WHITELIST and BLACKLIST must be lists of keys in Emacs'
+internal key representation (i.e., after calling `kbd' on the key
+description."
+  (or (member key whitelist)
+      (not (cl-member key blacklist
+                      :test #'evil-collection--keys-conflict))))
+
 (defun evil-collection-define-key (state map-sym &rest bindings)
   "Wrapper for `evil-define-key*' with additional features.
 Unlike `evil-define-key*' MAP-SYM should be a quoted keymap other than the
@@ -549,8 +569,7 @@ to filter keys on the basis of `evil-collection-key-whitelist' and
       (while bindings
         (let ((key (pop bindings))
               (def (pop bindings)))
-          (when (or (and whitelist (member key whitelist))
-                    (not (member key blacklist)))
+          (when (evil-collection--can-bind-key key whitelist blacklist)
             (annalist-record 'evil-collection 'keybindings
                              (list map-sym state key def)
                              :local (or (eq map-sym 'local)
@@ -564,8 +583,7 @@ to filter keys on the basis of `evil-collection-key-whitelist' and
   "Return whether or not we should bind KEY."
   (let* ((whitelist (mapcar 'kbd evil-collection-key-whitelist))
          (blacklist (mapcar 'kbd evil-collection-key-blacklist)))
-    (or (and whitelist (member key whitelist))
-        (not (member key blacklist)))))
+    (evil-collection--can-bind-key key whitelist blacklist)))
 
 (defun evil-collection--define-key (state map-sym bindings)
   "Workhorse function for `evil-collection-define-key'.


### PR DESCRIPTION
This change prevents evil-collection from binding a key that's a strict prefix or extension of a blacklisted key. E.g. Without this, evil-collection can end up binding a key that conflicts with a blacklisted key.

For example, by blacklisting "ab", evil-collection will be unable to bind any of "a", "ab", "abc", etc. However, it will be able to bind "ac", "acd", etc.

**Motivation:** I ran across this because I bind `;` _globally_ as my universal prefix (`C-u`) and add it to `evil-collection-key-blacklist` to prevent evil-collection from conflicting with it. Unfortunately, `evil-collection-dired` still binds `;d`, etc. in `dired-mode-map` which ends up overriding this binding.