### PR TITLE
fix(dashboard): Fix dashboard evil key lookup for registers

### DIFF
--- a/modes/dashboard/evil-collection-dashboard.el
+++ b/modes/dashboard/evil-collection-dashboard.el
@@ -48,7 +48,7 @@
     ;; added it would have to choose between the widget and losing
     ;; `evil-forward-word-end'. That's probably still better than
     ;; having a shortcut hint that isn't correct.
-    "e" (symbol-function (lookup-key dashboard-mode-map "e")))) ; registers
+    "e" (lookup-key dashboard-mode-map "e"))) ; registers
 
 ;;;###autoload
 (defun evil-collection-dashboard-setup ()


### PR DESCRIPTION
In `dashboard`, remove call to symbol-function as the return value of lookup-key can be a lambda. #900 fixes the rest, but missed one call. This PR fixes that.
