### PR TITLE
Add evil bindings for `elfeed-tree-mode`

### DIFF
--- a/modes/elfeed/evil-collection-elfeed.el
+++ b/modes/elfeed/evil-collection-elfeed.el
@@ -32,9 +32,11 @@
 
 (defvar elfeed-search-mode-map)
 (defvar elfeed-show-mode-map)
+(defvar elfeed-tree-mode-map)
 
 (defconst evil-collection-elfeed-maps '(elfeed-search-mode-map
-                                        elfeed-show-mode-map))
+					elfeed-show-mode-map
+					elfeed-tree-mode-map)
 
 ;;;###autoload
 (defun evil-collection-elfeed-setup ()
@@ -111,6 +113,12 @@
   ;; yu, like `eww'
   (evil-collection-define-operator-key 'yank 'elfeed-show-mode-map
     "u" 'elfeed-show-yank))
+
+  (evil-collection-set-readonly-bindings 'elfeed-tree-mode-map)
+  (evil-set-initial-state 'elfeed-tree-mode 'normal)
+  (evil-collection-define-key 'normal 'elfeed-tree-mode-map
+    ;; open
+    (kbd "RET") 'elfeed-tree-show)
 
 (provide 'evil-collection-elfeed)
 ;;; evil-collection-elfeed.el ends here


### PR DESCRIPTION
This commit adds the missing <RET> binding for elfeed-tree-mode.

This is based on the newly released `elfeed-tree-mode` (See [here](https://github.com/emacs-elfeed/elfeed/commit/072a609bb7e67c9b300ab22859a9423f7d7734d3)).
