### PR TITLE
eca: Add binding to allow submitting from insert mode

### DIFF
--- a/modes/eca/evil-collection-eca.el
+++ b/modes/eca/evil-collection-eca.el
@@ -45,7 +45,8 @@
       (kbd "RET") 'eca-chat--key-pressed-return)
     (evil-collection-define-key newline-state 'eca-chat-mode-map
       (kbd "<return>") 'eca-chat--key-pressed-newline
-      (kbd "RET") 'eca-chat--key-pressed-newline))
+      (kbd "RET") 'eca-chat--key-pressed-newline
+      (kbd "C-<return>") 'eca-chat--key-pressed-return))
 
   (evil-collection-define-key 'insert 'eca-chat-mode-map
     (kbd "S-<return>") 'eca-chat--key-pressed-newline)


### PR DESCRIPTION
### Brief summary of what the change does

Bind C-<return> to submit in eca-mode so one doesn't need to leave insert mode quite as much.

### Direct link to the related package repository

https://github.com/editor-code-assistant/eca-emacs

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->

<!-- Message of single commit: -->

[eca] Add binding for sending prompt in insert state