### PR TITLE
gptel: Bind S-<return> as promised by evil-collection-repl-submit-state

### DIFF
--- a/modes/gptel/evil-collection-gptel.el
+++ b/modes/gptel/evil-collection-gptel.el
@@ -50,9 +50,15 @@
   (let* ((submit evil-collection-repl-submit-state)
          (newline-state (if (eq submit 'normal) 'insert 'normal)))
     (evil-collection-define-key submit 'gptel-mode-map
-      (kbd "RET") 'gptel-send)
+      (kbd "RET") 'gptel-send
+      (kbd "<return>") 'gptel-send
+      (kbd "S-RET") 'newline
+      (kbd "S-<return>") 'newline)
     (evil-collection-define-key newline-state 'gptel-mode-map
-      (kbd "RET") 'newline))
+      (kbd "RET") 'newline
+      (kbd "<return>") 'newline
+      (kbd "S-RET") 'newline
+      (kbd "S-<return>") 'newline))
   (if evil-collection-gptel-want-shift-ret-menu
       (evil-collection-define-key '(normal visual) 'gptel-mode-map
         (kbd "S-RET") 'gptel-menu


### PR DESCRIPTION
### Brief summary of what the changes does

The setup for gptel uses `'evil-collection-repl-submit-state', but doesn't bind 'S-<return>' to 'newline' at all, not in "submit state" nor in "newline state". This change addresses that.

<!-- Message of single commit: -->

[gptel] Bind S-<return> according to the submit-state promise

The documentation of `evil-collection-repl-submit-state` ends within

    S-RET always inserts a newline regardless of state.

This change makes that true for gptel-mode.