### PR TITLE
Fix for `elfeed-tree-show` which is changed to `elfeed-tree-search`

### DIFF
--- a/modes/elfeed/evil-collection-elfeed.el
+++ b/modes/elfeed/evil-collection-elfeed.el
@@ -118,7 +118,7 @@
   (evil-set-initial-state 'elfeed-tree-mode 'normal)
   (evil-collection-define-key 'normal 'elfeed-tree-mode-map
     ;; open
-    (kbd "RET") 'elfeed-tree-show))
+    (kbd "RET") 'elfeed-tree-search))
 
 (provide 'evil-collection-elfeed)
 ;;; evil-collection-elfeed.el ends here


### PR DESCRIPTION
`elfeed-tree-show` command is obsolete and is now changed to `elfeed-tree-search`.