### PR TITLE
evil-collection-view: Remove text-scale related keybindings

### DIFF
--- a/modes/view/evil-collection-view.el
+++ b/modes/view/evil-collection-view.el
@@ -42,12 +42,6 @@
     (kbd "SPC") 'View-scroll-page-forward
     (kbd "S-SPC") 'View-scroll-page-backward
 
-    ;; zoom
-    "+" 'text-scale-increase
-    "=" 'text-scale-increase
-    "0" 'text-scale-adjust              ; TODO: Conflicts with `evil-beginning-of-line'.
-    "-" 'text-scale-decrease
-
     ;; refresh
     (kbd "gr") 'revert-buffer))
 


### PR DESCRIPTION
Kbd "0" conflicts with evil-beginning-of-line, and may be confusing for Evil users when '0' doesn't work as expected in view-mode. Per discussion in https://github.com/emacs-evil/evil-collection/issues/917 we are removing text-scale related bindings from view-mode, until we find more sensible keybindings, if we wish to add them back eventually.
