### PR TITLE
Add evil-ex-search-keymap to evil-collection-minibuffer-maps

### DIFF
--- a/modes/minibuffer/evil-collection-minibuffer.el
+++ b/modes/minibuffer/evil-collection-minibuffer.el
@@ -34,6 +34,7 @@
                                             minibuffer-local-completion-map
                                             minibuffer-local-must-match-map
                                             minibuffer-local-isearch-map
+                                            evil-ex-search-keymap
                                             evil-ex-completion-map))
 
 (defun evil-collection-minibuffer-insert ()


### PR DESCRIPTION
`evil-ex-search-keymap` is not part of `evil-collection-minibuffer-maps`. This means the normal-mode keys "c", "escape" and "RET" are not defined for this keymap.

That was fine in the past, because `evil-ex-search-keymap` inherited `minibuffer-local-map` and `minibuffer-local-map` is part of `evil-collection-minibuffer-maps`.

However, since commit b6daa765878d ("Add evil-command-line-map") in the Evil repo, `evil-ex-search-keymap` no longer inherits `minibuffer-local-map`. This means "c", "escape" and "RET" no longer work as reported in:
https://github.com/emacs-evil/evil/issues/2018

Make these keys work again by adding `evil-ex-search-keymap` to `evil-collection-minibuffer-maps`.
