### PR TITLE
evil-collection-ielm: Add evil-bindings for ielm

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -259,6 +259,7 @@ Used as a fallback when no explicit delay is specified for a mode in
     hungry-delete
     hyrolo
     ibuffer
+    ielm
     (image image-mode)
     image-dired
     image+

--- a/modes/ielm/evil-collection-ielm.el
+++ b/modes/ielm/evil-collection-ielm.el
@@ -1,0 +1,59 @@
+;;; evil-collection-ielm.el --- Bindings for `ielm' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Ian Pan <ianpan870102@gmail.com>
+
+;; Author: Ian Pan <ianpan870102@gmail.com>
+;; Maintainer: Ian Pan <ianpan870102@gmail.com>
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "26.3"))
+;; Keywords: evil, ielm, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Bindings for `ielm' (Inferior Emacs Lisp Mode).
+
+;;; Code:
+(require 'evil-collection)
+(require 'ielm nil t)
+
+(defvar inferior-emacs-lisp-mode-map)
+(defconst evil-collection-ielm-maps '(inferior-emacs-lisp-mode-map))
+
+(defcustom evil-collection-ielm-move-cursor-back nil
+  "Whether the cursor is moved backwards when exiting insert state."
+  :type 'boolean
+  :group 'ielm)
+
+(defun evil-collection-ielm-escape-stay ()
+  "Go back to normal state but don't move cursor backwards.
+Moving cursor backwards is the default vim behavior but
+it is not intuitive for some cases like REPL buffers."
+  (setq-local evil-move-cursor-back
+              evil-collection-ielm-move-cursor-back))
+
+;;;###autoload
+(defun evil-collection-ielm-setup ()
+  "Set up `evil' bindings for `ielm'."
+  (evil-set-initial-state 'inferior-emacs-lisp-mode 'insert)
+
+  (add-hook 'ielm-mode-hook #'evil-collection-ielm-escape-stay)
+
+  (let* ((submit evil-collection-repl-submit-state))
+    (evil-collection-define-key submit 'inferior-emacs-lisp-mode-map
+      (kbd "RET") #'ielm-return)))
+
+(provide 'evil-collection-ielm)
+;;; evil-collection-ielm.el ends here


### PR DESCRIPTION
Changes:

* **modes/ielm/evil-collection-ielm.el**: New file. Set initial state to insert, optionally prevent cursor-back on escape, and bind RET to ielm-return under evil-collection-repl-submit-state.
* **evil-collection.el (evil-collection--supported-modes):** Add ielm entry.

Context:

Before this commit, evil-collection does not support ielm mode directly, and falls back to using comint mode setup for ielm buffers. This resulted in no intelligent `ielm-return` for **RET** in either normal or insert state. Users would have to resort to switching to emacs-state to invoke ielm-return particularly with multi-line edits.

Note:

This commit provides the bare minimum support for ielm-return in evil-collection, and hopes to open the door for future contributions to ielm-specific support.

### Brief summary of what the package does

This commit provides the bare minimum support for ielm-return and evil-collection-ielm-move-cursor-back in evil-collection, and hopes to open the door for future contributions to ielm-specific support.

### Direct link to the package repository

https://github.com/emacs-evil/evil-collection

### Checklist

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-ielm)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-ielm-setup` with `defun`
- [x] define `evil-collection-ielm-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-ielm-`


## Testing

In addition to testing the checklist above (clean bytecompile, clean checkdoc), I manually tested evil-collection-ielm by loading my code in my Emacs (latest stable 30.2) config elpa directory, changing between insert and normal for `evil-collection-repl-submit-state`, changing between t and nil for `evil-collection-ielm-move-cursor-back` , and confirmed that all behaviors work as expected. The default value of evil-collection-ielm-move-cursor-back is set to nil, following the convention of evil-collection vterm and eshell.
