### PR TITLE
evil-collection-ielm: Bind '<return>' to ielm-return for GUI support

### DIFF
--- a/modes/ielm/evil-collection-ielm.el
+++ b/modes/ielm/evil-collection-ielm.el
@@ -53,7 +53,8 @@ it is not intuitive for some cases like REPL buffers."
 
   (let* ((submit evil-collection-repl-submit-state))
     (evil-collection-define-key submit 'inferior-emacs-lisp-mode-map
-      (kbd "RET") #'ielm-return)))
+      (kbd "RET")      #'ielm-return
+      (kbd "<return>") #'ielm-return)))
 
 (provide 'evil-collection-ielm)
 ;;; evil-collection-ielm.el ends here


### PR DESCRIPTION
RET only handles the enter key in TUI Emacs. We need to add `<return>` as well to support GUI Emacs.

### Brief summary of what the package does

A minor fix to support 'return' key in GUI Emacs as well.

### Direct link to the package repository

N/A

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
