### PR TITLE
eat: bind p/P to eat-yank in normal state

### DIFF
--- a/modes/eat/evil-collection-eat.el
+++ b/modes/eat/evil-collection-eat.el
@@ -30,9 +30,21 @@
 (require 'evil-collection)
 (require 'eat nil t)
 
-(defconst evil-collection-eat-maps '(eat-mode-map eat-line-mode-map))
+(defconst evil-collection-eat-maps '(eat-mode-map
+                                     eat-line-mode-map
+                                     eat-semi-char-mode-map
+                                     eat-char-mode-map
+                                     eat-eshell-semi-char-mode-map
+                                     eat-eshell-char-mode-map))
 
+;; The map symbols below are only referenced inside quoted lists in this
+;; file, so the byte-compiler does not actually require these declarations.
+;; Defining them keeps certain linters happy.
 (defvar eat-line-mode-map)
+(defvar eat-semi-char-mode-map)
+(defvar eat-char-mode-map)
+(defvar eat-eshell-semi-char-mode-map)
+(defvar eat-eshell-char-mode-map)
 
 (defvar-local evil-collection-eat-send-escape-to-eat-p nil
   "Track whether or not we send ESC to `eat' or `emacs'.")
@@ -95,7 +107,18 @@ SSH-accessed Emacs that also uses `evil-mode'."
     (kbd "C-w") 'eat-self-input
     (kbd "C-y") 'eat-self-input
     (kbd "C-z") 'eat-self-input
-    (kbd "<delete>") 'eat-self-input))
+    (kbd "<delete>") 'eat-self-input)
+
+  ;; Paste bindings: in a terminal, "paste before/after" is meaningless because
+  ;; the cursor position is controlled by the running program. Bind both `p'
+  ;; and `P' to `eat-yank' so the kill-ring is sent as terminal input.
+  (dolist (map '(eat-semi-char-mode-map
+                 eat-char-mode-map
+                 eat-eshell-semi-char-mode-map
+                 eat-eshell-char-mode-map))
+    (evil-collection-define-key 'normal map
+      (kbd "p") 'eat-yank
+      (kbd "P") 'eat-yank)))
 
 (provide 'evil-collection-eat)
 ;;; evil-collection-eat.el ends here


### PR DESCRIPTION
 
Same as #921 but on a dev branch so it is not polluted by my workflow


 Brief summary of what the package does

  eat (Emulate A Terminal) is a pure-Elisp terminal emulator with first-class eshell integration. This PR doesn't add a new mode —
  it extends the existing evil-collection-eat so that p and P in normal state send the kill-ring into the terminal via eat-yank,
  matching what evil-collection-term and evil-collection-vterm already do.

  Direct link to the package repository

  https://codeberg.org/akib/emacs-eat

  Checklist

  - byte-compiles cleanly
  - M-x checkdoc is happy
  - evil-collection-eat-setup is defined with defun (pre-existing; extended here)
  - evil-collection-eat-maps is defined with defconst (pre-existing; extended here with the four input sub-mode maps)
  - All functions start with evil-collection-eat- (no new functions added — the new bindings call eat-yank directly)

  ---
  Description


Written with help of AI, I understand if its not ok, but I've tested it

  Brings eat in line with term and vterm. evil-collection-term binds p to term-paste (line 149), and evil-collection-vterm binds p
  and P to send the kill-ring through the terminal (lines 283-284). eat had no equivalent — p in normal state just fell through to
  evil-paste-after which doesn't do anything sensible in a terminal buffer.

  Both p and P go to eat-yank. In a terminal there's no meaningful "before vs after" since the running program controls the cursor,
   so splitting them would be cosmetic at best. Binding both stops them falling through to evil-paste-before/-after.

  Insert state isn't touched — p self-inserts there, and C-y is already routed to eat-self-input by the existing setup.

  The bindings are placed on the four sub-mode input maps (eat-semi-char-mode-map, eat-char-mode-map,
  eat-eshell-semi-char-mode-map, eat-eshell-char-mode-map) rather than on eat-mode-map. Those maps are active when the user is
  actually interacting with a running terminal, which is when "send the kill-ring as terminal input" is the right semantics.
  eat-line-mode-map is deliberately excluded so line mode keeps evil's default paste — it's a buffer-edit mode, not a
  terminal-interaction mode. The four maps are also added to evil-collection-eat-maps for visibility to consumers of
  evil-collection-setup-hook.

  The defvars for the new map symbols aren't strictly required (the symbols only appear inside quoted lists, so the byte-compiler
  doesn't warn), but I added them to match the existing (defvar eat-line-mode-map) and keep other linters happy.