### PR TITLE
fix(gptel): use kbd macro for RET keybinding in context buffer

### DIFF
--- a/modes/gptel/evil-collection-gptel.el
+++ b/modes/gptel/evil-collection-gptel.el
@@ -76,7 +76,7 @@
       "q" 'gptel-context-quit
       "ZQ" 'gptel-context-quit
       "ZZ" 'gptel-context-confirm
-      "RET" 'gptel-context-visit)))
+      (kbd "RET") 'gptel-context-visit)))
 
 (provide 'evil-collection-gptel)
 ;;; evil-collection-gptel.el ends here


### PR DESCRIPTION
The `RET` keybinding in `gptel-context-buffer-mode-map` was passed as a bare string `"RET"` instead of using the `(kbd "RET")` macro. This is inconsistent with all other key definitions in the same file and does not correctly represent the Return key.

**Fix:** Replace `"RET"` with `(kbd "RET")` on line 79 of `evil-collection-gptel.el`.