### PR TITLE
Add fj

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -246,6 +246,7 @@ Used as a fallback when no explicit delay is specified for a mode in
     finder
     flycheck
     flymake
+    fj
     forge
     free-keys
     fzfa

--- a/modes/fj/README.org
+++ b/modes/fj/README.org
@@ -1,0 +1,44 @@
+* fj
+
+  Evil bindings for [[https://codeberg.org/martianh/fj.el][fj.el]], an Emacs client for Forgejo instances such as Codeberg.
+
+** Key bindings
+
+   The bindings add Evil-state alternatives for common fj.el actions while
+   leaving fj.el's own non-Evil keymaps intact.
+
+   | Command                  | Original  | Evil              |
+   |--------------------------+-----------+-------------------|
+   | =fj-switch-to-buffer=    | =/=       | =gb=              |
+   | =fj-view-reload=         | =g=       | =gr=              |
+   | =fj-item-next=           | =n=       | =]]=, =gj=, =C-j= |
+   | =fj-item-prev=           | =p=       | =[[=, =gk=, =C-k= |
+   | =fj-next-page=           | =.=       | =>=               |
+   | =fj-prev-page=           | =,=       | =<=               |
+   | =fj-tl-browse-entry=     | =B=       | =go=              |
+   | =fj-browse-view=         | =b=       | =go=              |
+   | =imenu=                  | =j=       | =gm=              |
+   | =fj-repo-copy-clone-url= | =u=, =L=  | =yc=              |
+   | =fj-copy-item-url=       | =C=       | =yu=              |
+   | =fj-item-comment=        | =C=, =c=  | =c=               |
+   | =fj-create-issue=        | =c=       | =C=               |
+   | =fj-repo-search=         | =s=       | =g/=              |
+   | =fj-list-issues-search=  | =s=       | =g/=              |
+   | =fj-repo-readme=         | =r=       | =r=               |
+   | =fj-item-edit=           | =e=       | =e=               |
+   | =fj-item-close=          | =k=       | =x=               |
+   | =fj-item-reopen=         | =o=       | =u=               |
+   | =fj-item-delete=         | =K=       | =X=               |
+   | =fj-item-edit-title=     | =t=       | =E=               |
+   | =fj-item-label-add=      | =l=       | =al=              |
+   | =fj-add-reaction=        | =r=       | =ar=              |
+   | =fj-view-pull-diff=      | =D=       | =gd=              |
+   | =fj-repo-commit-log=     | =L=       | =gL=              |
+   | =fj-merge-pull=          | =M=       | =gM=              |
+   | =fj-item-view-more=      | =>=       | =>=               |
+   | =fj-compose-send=        | =C-c C-c= | =ZZ=              |
+   | =fj-compose-cancel=      | =C-c C-k= | =ZQ=              |
+
+   Repo, issue, notification, commit, and user views start in normal state.
+   Compose buffers start in insert state and use normal-state =ZZ=/=ZQ= for
+   submit/cancel, matching other editable buffers in Evil Collection.

--- a/modes/fj/evil-collection-fj.el
+++ b/modes/fj/evil-collection-fj.el
@@ -1,0 +1,169 @@
+;;; evil-collection-fj.el --- Evil bindings for fj -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Evil bindings for fj.el.
+
+;;; Code:
+(require 'evil-collection)
+(require 'fj nil t)
+
+(defvar fj-commits-mode-map)
+(defvar fj-compose-comment-mode)
+(defvar fj-compose-comment-mode-map)
+(defvar fj-compose-mode)
+(defvar fj-compose-mode-map)
+(defvar fj-generic-map)
+(defvar fj-generic-tl-map)
+(defvar fj-issue-tl-mode-map)
+(defvar fj-item-view-mode-map)
+(defvar fj-notifications-mode-map)
+(defvar fj-owned-issues-tl-mode-map)
+(defvar fj-repo-tl-map)
+(defvar fj-repo-tl-mode-map)
+(defvar fj-user-repo-tl-mode-map)
+(defvar fj-users-mode-map)
+
+(defconst evil-collection-fj-maps
+  '(fj-commits-mode-map
+    fj-compose-comment-mode-map
+    fj-compose-mode-map
+    fj-generic-map
+    fj-generic-tl-map
+    fj-issue-tl-mode-map
+    fj-item-view-mode-map
+    fj-notifications-mode-map
+    fj-owned-issues-tl-mode-map
+    fj-repo-tl-map
+    fj-repo-tl-mode-map
+    fj-user-repo-tl-mode-map
+    fj-users-mode-map))
+
+(defconst evil-collection-fj-view-maps
+  '(fj-commits-mode-map
+    fj-item-view-mode-map
+    fj-notifications-mode-map
+    fj-users-mode-map))
+
+(defconst evil-collection-fj-tabulated-list-maps
+  '(fj-issue-tl-mode-map
+    fj-owned-issues-tl-mode-map
+    fj-repo-tl-map
+    fj-repo-tl-mode-map
+    fj-user-repo-tl-mode-map))
+
+(defun evil-collection-fj--setup-compose-buffer ()
+  "Set up Evil bindings for the current fj compose buffer."
+  (evil-local-set-key 'normal "ZQ" 'fj-compose-cancel)
+  (evil-local-set-key 'normal "ZZ" 'fj-compose-send)
+  (evil-insert-state))
+
+;;;###autoload
+(defun evil-collection-fj-setup ()
+  "Set up `evil' bindings for fj.el."
+  (dolist (mode '(fj-commits-mode
+                  fj-issue-tl-mode
+                  fj-item-view-mode
+                  fj-notifications-mode
+                  fj-owned-issues-tl-mode
+                  fj-repo-tl-mode
+                  fj-user-repo-tl-mode
+                  fj-users-mode))
+    (evil-set-initial-state mode 'normal))
+
+  (dolist (map evil-collection-fj-view-maps)
+    (evil-collection-set-readonly-bindings map))
+  (dolist (map evil-collection-fj-tabulated-list-maps)
+    (evil-collection-set-readonly-bindings map))
+
+  (evil-collection-define-key 'normal 'fj-generic-map
+    "gb" 'fj-switch-to-buffer
+    "go" 'fj-browse-view
+    "gr" 'fj-view-reload
+    "]]" 'fj-item-next
+    "[[" 'fj-item-prev
+    "gj" 'fj-item-next
+    "gk" 'fj-item-prev
+    (kbd "C-j") 'fj-item-next
+    (kbd "C-k") 'fj-item-prev
+    (kbd "<tab>") 'fj-next-tab-item
+    (kbd "<backtab>") 'fj-prev-tab-item)
+
+  (evil-collection-define-key 'normal 'fj-generic-tl-map
+    "gb" 'fj-switch-to-buffer
+    "go" 'fj-tl-browse-entry
+    "gm" 'imenu
+    "gr" 'fj-view-reload
+    ">" 'fj-next-page
+    "<" 'fj-prev-page
+    (kbd "<tab>") 'fj-next-tab-item
+    (kbd "<backtab>") 'fj-prev-tab-item)
+
+  (evil-collection-define-key 'normal 'fj-repo-tl-map
+    (kbd "RET") 'fj-repo-list-issues
+    (kbd "M-RET") 'fj-repo-list-pulls
+    "C" 'fj-create-issue
+    "r" 'fj-repo-readme
+    "g/" 'fj-repo-search
+    "gm" 'imenu
+    "go" 'fj-tl-browse-entry)
+  (evil-collection-define-operator-key 'yank 'fj-repo-tl-map
+    "c" 'fj-repo-copy-clone-url)
+
+  (evil-collection-define-key 'normal 'fj-issue-tl-mode-map
+    (kbd "RET") 'fj-issues-tl-view
+    "c" 'fj-item-comment
+    "C" 'fj-create-issue
+    "e" 'fj-item-edit
+    "E" 'fj-item-edit-title
+    "g/" 'fj-list-issues-search
+    "x" 'fj-item-close
+    "X" 'fj-item-delete
+    "u" 'fj-item-reopen
+    "al" 'fj-item-label-add
+    "gL" 'fj-repo-commit-log
+    "gm" 'imenu
+    "go" 'fj-tl-browse-entry)
+  (evil-collection-define-operator-key 'yank 'fj-issue-tl-mode-map
+    "c" 'fj-repo-copy-clone-url
+    "u" 'fj-copy-item-url)
+
+  (evil-collection-define-key 'normal 'fj-item-view-mode-map
+    "c" 'fj-item-comment
+    "e" 'fj-item-edit
+    "E" 'fj-item-edit-title
+    "r" 'fj-add-reaction
+    "g/" 'fj-list-issues-search
+    "x" 'fj-item-close
+    "X" 'fj-item-delete
+    "u" 'fj-item-reopen
+    "al" 'fj-item-label-add
+    "ar" 'fj-add-reaction
+    "gd" 'fj-view-pull-diff
+    "gL" 'fj-repo-commit-log
+    "gM" 'fj-merge-pull
+    ">" 'fj-item-view-more)
+  (evil-collection-define-operator-key 'yank 'fj-item-view-mode-map
+    "u" 'fj-copy-item-url)
+
+  (evil-collection-define-key 'normal 'fj-notifications-mode-map
+    "g/" 'fj-list-issues-search
+    ">" 'fj-next-page
+    "<" 'fj-prev-page)
+
+  (evil-collection-define-key 'normal 'fj-commits-mode-map
+    "g/" 'fj-list-issues-search
+    "gL" 'fj-repo-commit-log)
+
+  (evil-collection-define-key 'normal 'fj-users-mode-map
+    "g/" 'fj-list-issues-search
+    "gL" 'fj-repo-commit-log
+    ">" 'fj-next-page
+    "<" 'fj-prev-page)
+
+  (add-hook 'fj-compose-comment-mode-hook
+            #'evil-collection-fj--setup-compose-buffer)
+  (add-hook 'fj-compose-mode-hook
+            #'evil-collection-fj--setup-compose-buffer))
+
+(provide 'evil-collection-fj)
+;;; evil-collection-fj.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

fj.el is an Emacs client for Forgejo instances such as Codeberg. It provides tabulated views for repositories, issues, pull requests, notifications, commits, and users, plus item timeline views and compose buffers for creating/editing issues and comments.

This PR adds evil-collection bindings for fj.el's read-only views, tabulated-list views, and compose buffers.

### Direct link to the package repository

https://codeberg.org/martianh/fj.el

### Checklist

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy
- [x] define `evil-collection-fj-setup` with `defun`
- [x] define `evil-collection-fj-maps` with `defconst`
- [x] All functions start with `evil-collection-fj-`
