### PR TITLE
fix(elfeed): removes deprecated elfeed-kill-buffer from keymap and adds alternative

### DIFF
--- a/modes/elfeed/README.org
+++ b/modes/elfeed/README.org
@@ -43,7 +43,7 @@
    | =elfeed-show-next-link=                 | =TAB=    | =TAB=             |
    | =scroll-up-command=                     | =SPC=    | =SPC=             |
    | =scroll-down-command=                   | =S-SPC=  | =S-SPC=           |
-   | =elfeed-kill-buffer=                    | =q=      | =q=, =ZQ=, =ZZ=   |
+   | =kill-current-buffer=                   | =q=      | =q=, =ZQ=, =ZZ=   |
 
 ** elfeed-tree-mode-map
 

--- a/modes/elfeed/evil-collection-elfeed.el
+++ b/modes/elfeed/evil-collection-elfeed.el
@@ -100,9 +100,9 @@
                         'prev-item 'elfeed-show-prev
                         'next-section 'elfeed-show-next
                         'prev-section 'elfeed-show-prev
-                        'quit 'elfeed-kill-buffer
-                        'quit-save 'elfeed-kill-buffer
-                        'quit-cancel 'elfeed-kill-buffer
+                        'quit 'kill-current-buffer
+                        'quit-save 'kill-current-buffer
+                        'quit-cancel 'kill-current-buffer
                         'refresh 'elfeed-show-refresh
                         'search-or-filter 'elfeed-show-new-live-search
                         'cycle-next 'elfeed-show-next-link)


### PR DESCRIPTION
### Brief summary of what the package does

Elfeed 4.0.0 is out. One of its commands was deprecated, this simple pull request provides a fix for annoying echo area warnings/messages.

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
