### PR TITLE
Add bindings for `agent-shell-manager`

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -193,6 +193,7 @@ Used as a fallback when no explicit delay is specified for a mode in
   `(2048-game
     ag
     agent-shell
+    agent-shell-manager
     alchemist
     anaconda-mode
     apropos

--- a/modes/agent-shell-manager/README.org
+++ b/modes/agent-shell-manager/README.org
@@ -1,0 +1,40 @@
+* agent-shell-manager
+
+  Evil bindings for
+  [[https://github.com/jethrokuan/agent-shell-manager][agent-shell-manager]] --
+  a =tabulated-list= buffer manager for
+  [[https://github.com/xenodium/agent-shell][agent-shell]].
+
+  =agent-shell-manager-mode= derives from =tabulated-list-mode=, so the usual
+  motions work; these bindings map its manager commands onto evil keys and,
+  crucially, make =RET= visit the entry at point in normal state.
+
+** agent-shell-manager-mode-map
+
+*** Navigation (normal state)
+
+    | Command                     | Default | Evil  |
+    |-----------------------------+---------+-------|
+    | =agent-shell-manager-goto=  | =RET=   | =RET= |
+
+*** Manager commands (normal state)
+
+    Placed behind the =g= prefix when =evil-collection-want-g-bindings= is
+    non-nil, otherwise bound to their default-ish single keys.
+
+    | Command                              | Default   | Evil (g) | Evil (no g) |
+    |--------------------------------------+-----------+----------+-------------|
+    | =agent-shell-manager-refresh=        | =g=       | =gr=     | =gr=        |
+    | =agent-shell-manager-kill=           | =k=       | =gk=     | =K=         |
+    | =agent-shell-manager-new=            | =c=       | =gc=     | =c=         |
+    | =agent-shell-manager-restart=        | =r=       | =gR=     | =R=         |
+    | =agent-shell-manager-delete-killed=  | =d=       | =gd=     | =d=         |
+    | =agent-shell-manager-set-mode=       | =m=       | =gm=     | =m=         |
+    | =agent-shell-manager-set-model=      | =M=       | =gv=     | =M=         |
+    | =agent-shell-manager-interrupt=      | =C-c C-c= | =gx=     | =x=         |
+    | =agent-shell-manager-view-traffic=   | =t=       | =gt=     | =t=         |
+    | =agent-shell-manager-toggle-logging= | =l=       | =gl=     | =l=         |
+    | =quit-window=                        | =q=       | =q=      | =q=         |
+
+    =C-c C-c= (interrupt) is bound in normal state regardless of the =g=
+    setting.

--- a/modes/agent-shell-manager/evil-collection-agent-shell-manager.el
+++ b/modes/agent-shell-manager/evil-collection-agent-shell-manager.el
@@ -70,7 +70,7 @@
       "M" 'agent-shell-manager-set-model
       "x" 'agent-shell-manager-interrupt
       "t" 'agent-shell-manager-view-traffic
-      "l" 'agent-shell-manager-toggle-logging)))
+      "L" 'agent-shell-manager-toggle-logging)))
 
 (provide 'evil-collection-agent-shell-manager)
 ;;; evil-collection-agent-shell-manager.el ends here

--- a/modes/agent-shell-manager/evil-collection-agent-shell-manager.el
+++ b/modes/agent-shell-manager/evil-collection-agent-shell-manager.el
@@ -1,0 +1,75 @@
+;;; evil-collection-agent-shell-manager.el --- Bindings for agent-shell-manager -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Julio Borja Barra
+
+;; Author: Julio Borja Barra
+;; Maintainer: Julio Borja Barra
+;; URL: https://github.com/emacs-evil/evil-collection
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "29.1"))
+;; Keywords: evil, agent-shell-manager, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Evil bindings for `agent-shell-manager' -- the tabulated-list buffer
+;; manager for `agent-shell'.
+
+;;; Code:
+(require 'evil-collection)
+(require 'agent-shell-manager nil t)
+
+(defconst evil-collection-agent-shell-manager-maps '(agent-shell-manager-mode-map))
+
+(defvar agent-shell-manager-mode-map)
+
+;;;###autoload
+(defun evil-collection-agent-shell-manager-setup ()
+  "Set up `evil' bindings for `agent-shell-manager'."
+  (evil-set-initial-state 'agent-shell-manager-mode 'normal)
+
+  (evil-collection-define-key 'normal 'agent-shell-manager-mode-map
+    (kbd "C-c C-c") 'agent-shell-manager-interrupt)
+
+  (evil-collection-bind 'agent-shell-manager-mode-map
+                        'action 'agent-shell-manager-goto
+                        'refresh 'agent-shell-manager-refresh
+                        'quit 'quit-window
+                        'quit-save 'quit-window
+                        'quit-cancel 'quit-window)
+
+  (if evil-collection-want-g-bindings
+      (evil-collection-define-key 'normal 'agent-shell-manager-mode-map
+        "gk" 'agent-shell-manager-kill
+        "gc" 'agent-shell-manager-new
+        "gR" 'agent-shell-manager-restart
+        "gd" 'agent-shell-manager-delete-killed
+        "gm" 'agent-shell-manager-set-mode
+        "gv" 'agent-shell-manager-set-model
+        "gx" 'agent-shell-manager-interrupt
+        "gt" 'agent-shell-manager-view-traffic
+        "gl" 'agent-shell-manager-toggle-logging)
+    (evil-collection-define-key 'normal 'agent-shell-manager-mode-map
+      "K" 'agent-shell-manager-kill
+      "c" 'agent-shell-manager-new
+      "R" 'agent-shell-manager-restart
+      "d" 'agent-shell-manager-delete-killed
+      "m" 'agent-shell-manager-set-mode
+      "M" 'agent-shell-manager-set-model
+      "x" 'agent-shell-manager-interrupt
+      "t" 'agent-shell-manager-view-traffic
+      "l" 'agent-shell-manager-toggle-logging)))
+
+(provide 'evil-collection-agent-shell-manager)
+;;; evil-collection-agent-shell-manager.el ends here

--- a/modes/agent-shell-manager/evil-collection-agent-shell-manager.el
+++ b/modes/agent-shell-manager/evil-collection-agent-shell-manager.el
@@ -60,11 +60,12 @@
         "gx" 'agent-shell-manager-interrupt
         "gt" 'agent-shell-manager-view-traffic
         "gl" 'agent-shell-manager-toggle-logging)
+    (evil-collection-bind 'agent-shell-manager-mode-map
+                          'delete 'agent-shell-manager-delete-killed)
     (evil-collection-define-key 'normal 'agent-shell-manager-mode-map
       "K" 'agent-shell-manager-kill
       "c" 'agent-shell-manager-new
       "R" 'agent-shell-manager-restart
-      "d" 'agent-shell-manager-delete-killed
       "m" 'agent-shell-manager-set-mode
       "M" 'agent-shell-manager-set-model
       "x" 'agent-shell-manager-interrupt


### PR DESCRIPTION
### Brief summary of what the package does

Evil bindings for `agent-shell-manager`, a `tabulated-list` buffer manager for `agent-shell`. Adds mapping for `RET` to visit entries and all manager actions onto convenient keys.

### Direct link to the package repository

https://github.com/jethrokuan/agent-shell-manager

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [X] byte-compiles cleanly
- [X] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [X] define `evil-collection-mpc-setup` with `defun`
- [X] define `evil-collection-mpc-mode-maps` with `defconst`
- [X] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->

<!-- Message of single commit: -->

feat(agent-shell-manager): Add evil bindings for agent-shell-manager