### PR TITLE
Updated obsolete commands related to read status and tagging in elfeed

### DIFF
--- a/modes/elfeed/evil-collection-elfeed.el
+++ b/modes/elfeed/evil-collection-elfeed.el
@@ -78,10 +78,10 @@
                           'quit-cancel 'elfeed-search-quit-window))
 
   (evil-collection-define-key '(normal visual) 'elfeed-search-mode-map
-    "+" 'elfeed-search-tag-all
-    "-" 'elfeed-search-untag-all
-    "U" 'elfeed-search-tag-all-unread
-    "u" 'elfeed-search-untag-all-unread)
+    "+" 'elfeed-search-tag
+    "-" 'elfeed-search-untag
+    "U" 'elfeed-search-tag-unread
+    "u" 'elfeed-search-untag-unread)
 
   (evil-collection-set-readonly-bindings 'elfeed-show-mode-map)
   (evil-set-initial-state 'elfeed-show-mode 'normal)


### PR DESCRIPTION
Certain commands are now obsolete in elfeed as of version 4.1.1. This PR updates the commands to the latest release of elfeed.

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [X] byte-compiles cleanly
- [X] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [X] define `evil-collection-mpc-setup` with `defun`
- [X] define `evil-collection-mpc-mode-maps` with `defconst`
- [X] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
