### PR TITLE
Add configuration for grep-edit-mode

### DIFF
--- a/modes/grep/README.org
+++ b/modes/grep/README.org
@@ -2,13 +2,20 @@
 
   Evil bindings for [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Grep-Searching.html][grep]].
 
-** Key bindings
+** grep-mode-map key bindings
 
-   | Command                    | Original | Evil  |
-   |----------------------------+----------+-------|
-   | =evil-search-next=         | n/a      | =n=   |
-   | =next-error-no-select=     | =n=      | =C-j= |
-   | =previous-error-no-select= | =p=      | =C-k= |
+   | Command                         | Original | Evil  |
+   |---------------------------------+----------+-------|
+   | =evil-search-next=              | n/a      | =n=   |
+   | =next-error-no-select=          | =n=      | =C-j= |
+   | =previous-error-no-select=      | =p=      | =C-k= |
+   | =grep-change-to-grep-edit-mode= | =e=      | =I=   |
+
+** grep-edit-mode-map key bindings
+
+   | Command                  | Original  | Evil       |
+   |--------------------------+-----------+------------|
+   | =grep-edit-save-changes= | =C-c C-c= | =ZZ=, =:w= |
 
 ** Integrations
 

--- a/modes/grep/evil-collection-grep.el
+++ b/modes/grep/evil-collection-grep.el
@@ -30,7 +30,10 @@
 (require 'evil-collection)
 (require 'grep)
 
-(defconst evil-collection-grep-maps '(grep-mode-map))
+(defvar grep-edit-mode-map) ;; might be missing if it's older Emacs
+
+(defconst evil-collection-grep-maps '(grep-mode-map
+                                      grep-edit-mode-map))
 
 ;;;###autoload
 (defun evil-collection-grep-setup ()
@@ -43,7 +46,13 @@
   ;; `wgrep' integration
   (when (fboundp 'wgrep-setup)
     (evil-collection-define-key 'normal 'grep-mode-map
-      "i" 'wgrep-change-to-wgrep-mode)))
+      "i" 'wgrep-change-to-wgrep-mode))
+
+  (when (>= emacs-major-version 31)
+    (evil-collection-define-key 'normal 'grep-mode-map
+      "I" 'grep-change-to-grep-edit-mode)
+    (evil-collection-bind 'grep-edit-mode-map
+                          'quit-save 'grep-edit-save-changes)))
 
 (provide 'evil-collection-grep)
 ;;; evil-collection-grep.el ends here


### PR DESCRIPTION
### Brief summary of what the package does

grep-edit-mode is Emacs 31's built-in alternative to wgrep.  Wgrep is more feature-complete,  so I bind it as a fallback when wgrep is not available.

### Direct link to the package repository

https://github.com/emacs-mirror/emacs/blob/emacs-31/lisp/progmodes/grep.el#L1125

### Checklist

<!-- Please confirm with `x`: -->

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

<!-- After submitting, please fix any problems the CI reports. -->
