### PR TITLE
Add missing git-timemachine bindings

### DIFF
--- a/modes/git-timemachine/evil-collection-git-timemachine.el
+++ b/modes/git-timemachine/evil-collection-git-timemachine.el
@@ -41,10 +41,14 @@
     "\C-k" 'git-timemachine-show-previous-revision
     "\C-j" 'git-timemachine-show-next-revision
     "gtg"  'git-timemachine-show-nth-revision
+    "gth"  'git-timemachine-show-nearest-revision
     "gtt"  'git-timemachine-show-revision-fuzzy
+    "gti"  'git-timemachine-show-revision-introducing
     "gty"  'git-timemachine-kill-abbreviated-revision
     "gtY"  'git-timemachine-kill-revision
-    "gtb"  'git-timemachine-blame)
+    "gtb"  'git-timemachine-blame
+    "gtc"  'git-timemachine-show-commit
+    "gt?"  'git-timemachine-help)
 
   (evil-collection-bind-minor-mode 'quit 'git-timemachine-mode 'git-timemachine-quit))
 


### PR DESCRIPTION
### Brief summary of what the package does

Walk through git revisions of a file

### Direct link to the package repository

https://codeberg.org/pidu/git-timemachine

### Checklist

Assume you're working on `mpc` mode:

- [x] byte-compiles cleanly
- [x] `M-x checkdoc` is happy. Don't manually write `(provide 'evil-collection-mpc)`, `M-x checkdoc` can do it automatically for you
- [x] define `evil-collection-mpc-setup` with `defun`
- [x] define `evil-collection-mpc-mode-maps` with `defconst`
- [x] All functions should start with `evil-collection-mpc-`

This pr tries to remain faithful to the standard emacs bindings

(Native package defines these)
```elisp
(define-minor-mode git-timemachine-mode
 "Git Timemachine, feel the wings of history."
 :init-value nil
 :lighter " Timemachine"
 :keymap
 '(("p" . git-timemachine-show-previous-revision)
   ("n" . git-timemachine-show-next-revision)
   ("g" . git-timemachine-show-nth-revision)
   ("h" . git-timemachine-show-nearest-revision)
   ("t" . git-timemachine-show-revision-fuzzy)
   ("i" . git-timemachine-show-revision-introducing)
   ("q" . git-timemachine-quit)
   ("w" . git-timemachine-kill-abbreviated-revision)
   ("W" . git-timemachine-kill-revision)
   ("b" . git-timemachine-blame)
   ("c" . git-timemachine-show-commit)
   ("?" . git-timemachine-help))
 :group 'git-timemachine)
```